### PR TITLE
Use the identifier directly instead of a hash

### DIFF
--- a/analysis/source/source-node.js
+++ b/analysis/source/source-node.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const util = require('util')
-const { murmurHash128 } = require('murmurhash-native')
+const crypto = require('crypto')
 const Frames = require('../stack-trace/frames.js')
 const StackTrace = require('../stack-trace/stack-trace.js')
 const TraceEvent = require('../trace-event/trace-event.js')
@@ -37,7 +37,11 @@ class SourceNode {
            ` parentAsyncId:${options.stylize(this.parentAsyncId, 'number')},` +
            ` triggerAsyncId:${options.stylize(this.triggerAsyncId, 'number')},` +
            ` executionAsyncId:${options.stylize(this.executionAsyncId, 'number')},` +
-           ` identifier:${options.stylize(this.identifier, 'special')}>`
+           ` identifier:${options.stylize(this.identifier && this.hash().slice(0, 16), 'special')}>`
+  }
+
+  hash () {
+    return this.identifier && crypto.createHash('sha256').update(this.identifier).digest('hex')
   }
 
   toJSON ({short} = {short: false}) {
@@ -67,7 +71,7 @@ class SourceNode {
   }
 
   setIdentifier (identifier) {
-    this.identifier = murmurHash128(identifier)
+    this.identifier = identifier
   }
 
   setParentAsyncId (asyncId) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "async": "^2.5.0",
     "browserify": "^14.5.0",
     "endpoint": "^0.4.5",
-    "murmurhash-native": "^3.2.1",
     "protocol-buffers": "^3.2.1",
     "pump": "^1.0.2",
     "stream-template": "0.0.4",

--- a/test/analysis-source.test.js
+++ b/test/analysis-source.test.js
@@ -2,6 +2,7 @@
 
 const test = require('tap').test
 const util = require('util')
+const crypto = require('crypto')
 const StackTrace = require('../analysis/stack-trace/stack-trace.js')
 const TraceEvent = require('../analysis/trace-event/trace-event.js')
 const RawEvent = require('../analysis/raw-event/raw-event.js')
@@ -27,6 +28,12 @@ test('Source Node - sourceNode.inspect', function (t) {
     util.inspect(sourceNode),
     '<SourceNode type:CUSTOM, asyncId:2, parentAsyncId:1,' +
     ' triggerAsyncId:1, executionAsyncId:0, identifier:null>'
+  )
+  sourceNode.setIdentifier('string will be the id')
+  t.strictEqual(
+    util.inspect(sourceNode),
+    '<SourceNode type:CUSTOM, asyncId:2, parentAsyncId:1,' +
+    ' triggerAsyncId:1, executionAsyncId:0, identifier:66e4917ca59cec24>'
   )
   t.end()
 })
@@ -128,11 +135,25 @@ test('Source Node - sourceNode.makeRoot', function (t) {
 
 test('Source Node - sourceNode.setIdentifier', function (t) {
   const sourceNode = new FakeSourceNode({ asyncId: 2 })
-  sourceNode.setIdentifier('string will be hashed')
+
+  t.strictEqual(
+    sourceNode.hash(),
+    null
+  )
+  t.strictEqual(
+    sourceNode.toJSON().identifier,
+    null
+  )
+
+  sourceNode.setIdentifier('string will be the id')
 
   t.strictEqual(
     sourceNode.toJSON().identifier,
-    '6acf67129f52ba03567d4189016f4c2b'
+    'string will be the id'
+  )
+  t.strictEqual(
+    sourceNode.hash(),
+    crypto.createHash('sha256').update('string will be the id').digest('hex')
   )
 
   t.end()


### PR DESCRIPTION
This makes us rely on 0 native modules, which makes using node master a lot easier