### PR TITLE
Add ids and children to layoutNodes

### DIFF
--- a/visualizer/layout/layout.js
+++ b/visualizer/layout/layout.js
@@ -32,6 +32,7 @@ class Layout {
     nodes.forEach(node => {
       const parent = node.parentId ? this.layoutNodes.get(node.getParentNode().id) : null
       this.layoutNodes.set(node.id, new LayoutNode(node, parent))
+      if (parent) parent.children.push(node.id)
     })
   }
 
@@ -108,11 +109,13 @@ class Layout {
 
 class LayoutNode {
   constructor (node, parent) {
+    this.id = node.id
     this.node = node
     this.stem = null
     this.position = null
     this.inboundConnection = null
     this.parent = parent || null
+    this.children = []
   }
 }
 

--- a/visualizer/layout/stems.js
+++ b/visualizer/layout/stems.js
@@ -26,7 +26,7 @@ class Stem {
       const ancestorStem = layout.layoutNodes.get(ancestorId).stem
       this.ancestors.totalBetween += ancestorStem.ownBetween
       this.ancestors.totalDiameter += ancestorStem.ownDiameter
-      if (!node.children.length) {
+      if (!layoutNode.children.length) {
         ancestorStem.leaves.ids.push(node.id)
       }
     }


### PR DESCRIPTION
Important small addition to layoutNodes that allows us to put the bugfix in https://github.com/nearform/node-clinic-bubbleprof/pull/77 in to its more correct state instead of a temporary state. Passes all the same tests.

As commented above https://github.com/nearform/node-clinic-bubbleprof/pull/77#pullrequestreview-112342847 we should be testing if something is a leaf or not through whether its layoutNode has children because a node can be a leaf if it has children not included in this layout, this PR makes that possible and fixes that.