### PR TITLE
Make roots unclumpable

### DIFF
--- a/test/visualizer-layout-node-allocation.test.js
+++ b/test/visualizer-layout-node-allocation.test.js
@@ -279,7 +279,7 @@ test('Visualizer layout - node allocation - can handle collapsets', function (t)
   t.ok(layout)
   layout.processHierarchy({ collapseNodes: true })
   // Arbitrary Map order being issue here
-  const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 1, 3, 4, 6].every(c => ('' + key).includes(c)))
+  const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 3, 4, 6].every(c => ('' + key).includes(c)))
   t.ok(clumpId)
   layout.positioning.formClumpPyramid()
   layout.positioning.placeNodes()
@@ -293,7 +293,7 @@ test('Visualizer layout - node allocation - can handle collapsets', function (t)
 
   const distanceById = {}
   for (const layoutNode of layout.layoutNodes.values()) {
-    if (layoutNode.id === clumpId) {
+    if (layoutNode.id === 1) {
       distanceById[layoutNode.id] = 0
       continue
     }
@@ -305,8 +305,8 @@ test('Visualizer layout - node allocation - can handle collapsets', function (t)
     }).length
   }
 
-  t.equal(positionById[clumpId].x.toFixed(0), (layout.settings.svgWidth / 2).toFixed(0))
-  t.equal(positionById[clumpId].y.toFixed(0), (layout.settings.svgDistanceFromEdge + 1).toFixed(0))
+  t.equal(positionById[1].x.toFixed(0), (layout.settings.svgWidth / 2).toFixed(0))
+  t.equal(positionById[1].y.toFixed(0), (layout.settings.svgDistanceFromEdge + 1).toFixed(0))
 
   t.ok(positionById[7].y > positionById[clumpId].y)
   t.ok(positionById[7].x < positionById[clumpId].x)
@@ -334,7 +334,7 @@ test('Visualizer layout - node allocation - can handle collapsets with clumpy le
   t.ok(layout)
   layout.processHierarchy({ collapseNodes: true })
   // Arbitrary Map order being issue here
-  const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 1, 2, 3, 4, 6].every(c => ('' + key).includes(c)))
+  const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 2, 3, 4, 6].every(c => ('' + key).includes(c)))
   t.ok(clumpId)
   layout.positioning.formClumpPyramid()
   layout.positioning.placeNodes()
@@ -348,7 +348,7 @@ test('Visualizer layout - node allocation - can handle collapsets with clumpy le
 
   const distanceById = {}
   for (const layoutNode of layout.layoutNodes.values()) {
-    if (layoutNode.id === clumpId) {
+    if (layoutNode.id === 1) {
       distanceById[layoutNode.id] = 0
       continue
     }
@@ -360,8 +360,8 @@ test('Visualizer layout - node allocation - can handle collapsets with clumpy le
     }).length
   }
 
-  t.equal(positionById[clumpId].x.toFixed(0), (layout.settings.svgWidth / 2).toFixed(0))
-  t.equal(positionById[clumpId].y.toFixed(0), (layout.settings.svgDistanceFromEdge).toFixed(0))
+  t.equal(positionById[1].x.toFixed(0), (layout.settings.svgWidth / 2).toFixed(0))
+  t.equal(positionById[1].y.toFixed(0), (layout.settings.svgDistanceFromEdge).toFixed(0))
 
   t.ok(positionById[5].y > positionById[clumpId].y)
   t.ok(positionById[5].x < positionById[clumpId].x)

--- a/test/visualizer-layout-positioning.test.js
+++ b/test/visualizer-layout-positioning.test.js
@@ -228,7 +228,7 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets', functi
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] })
   layout.processHierarchy({ collapseNodes: true })
   // Arbitrary Map order being issue here
-  const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 1, 2, 3, 6].every(c => key.includes(c)))
+  const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 2, 3, 6].every(c => ('' + key).includes(c)))
   t.ok(clumpId)
   const positioning = layout.positioning
   positioning.formClumpPyramid()
@@ -253,7 +253,7 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets with clu
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] })
   layout.processHierarchy({ collapseNodes: true })
   // Arbitrary Map order being issue here
-  const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 1, 2, 3, 6, 9].every(c => key.includes(c)))
+  const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 2, 3, 6, 9].every(c => ('' + key).includes(c)))
   t.ok(clumpId)
   const positioning = layout.positioning
   positioning.formClumpPyramid()

--- a/visualizer/layout/layout.js
+++ b/visualizer/layout/layout.js
@@ -173,7 +173,8 @@ class Layout {
       let combinedSelfCollapse
       let combinedChildrenCollapse
       const selfBelowThreshold = isBelowThreshold(layoutNode.node)
-      if (selfBelowThreshold && collapsibleChildren.length) {
+      const selfTopNode = topLayoutNodes.includes(layoutNode)
+      if (selfBelowThreshold && collapsibleChildren.length && !selfTopNode) {
         // Combine children and self
         combinedSelfCollapse = new CollapsedLayoutNode([layoutNode].concat(collapsibleChildren), parent, grandChildren.concat(childrenAboveThreshold.map(child => child.id)))
       } else if (collapsibleChildren.length >= 2) {
@@ -183,7 +184,7 @@ class Layout {
       }
 
       let nodesToIndex
-      if (selfBelowThreshold) {
+      if (selfBelowThreshold && !selfTopNode) {
         // If self collapsible, index only childrenAboveThreshold
         nodesToIndex = childrenAboveThreshold
       } else {


### PR DESCRIPTION
This addresses the issue where sometimes new sublayout would consist entirely of just one clump, which was confusing parts of the system that depend on existence of root
On top of that a single-node sublayout is not that useful

Before
![101 - file____users_km_work_bubble_node-clinic-bubbleprof-samples_8952 clinic-bubbleprof html](https://user-images.githubusercontent.com/10513845/39129742-29d4c31e-4703-11e8-8ef7-573cec3f4bba.png)

After
![100 - file____users_km_work_bubble_node-clinic-bubbleprof-samples_8952 clinic-bubbleprof html](https://user-images.githubusercontent.com/10513845/39129749-2dd61a3a-4703-11e8-8a84-91aa84a33add.png)

