### PR TITLE
Jump from previous frame to previous node (not to merge yet)

### DIFF
--- a/visualizer/draw/frames.js
+++ b/visualizer/draw/frames.js
@@ -112,6 +112,15 @@ class Frames extends HtmlContent {
             .classed('collapsed', !isThisNode)
             .classed('this-node', isThisNode)
 
+          if (!isThisNode) {
+            d3Group.insert('a', ':first-child')
+              .classed('jump-to-node', true)
+              .text('Select on diagram')
+              .on('click', () => {
+                this.ui.jumpToAggregateNode(frame.dataNode)
+              })
+          }
+
           header += `${flatMapDeep(frame).length} frames from `
           header += `${isThisNode ? 'this async_hook' : `previous async_hook "${frame.dataNode.name}"`}`
           header += `<div class="delays">${this.getDelaysText(frame.dataNode)}</span>`
@@ -119,8 +128,11 @@ class Frames extends HtmlContent {
           d3Group.classed(frame.party[0], true)
             .classed('collapsed', frame.party[0] !== 'user')
           header += `${frame.length} frame${frame.length === 1 ? '' : 's'} from ${frame.party[1]}`
+          d3SubCollapseControl.html(header)
         }
-        d3SubCollapseControl.html(header)
+
+        d3SubCollapseControl
+          .html(header)
           .on('click', () => {
             d3Group.classed('collapsed', !d3Group.classed('collapsed'))
           })

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -255,6 +255,15 @@ body[data-highlight-party='nodecore'] #header .interactive-key.party-nodecore .p
   margin: 12px 0;
 }
 
+#frames-panel .jump-to-node {
+  display: block;
+  float: right;
+  font-weight: bold;
+  color: var(--cyan);
+  cursor: pointer;
+  margin-right: 32px;
+}
+
 #frames-panel .sub-collapse-control {
   cursor: pointer;
   color: var(--cyan);
@@ -277,7 +286,9 @@ body[data-highlight-party='nodecore'] #header .interactive-key.party-nodecore .p
 }
 
 #frames-panel .sub-collapse-control:hover,
-#frames-panel .sub-collapse-control:focus {
+#frames-panel .sub-collapse-control:focus,
+#frames-panel .jump-to-node:hover,
+#frames-panel .jump-to-node:focus {
   color: var(--cyan-highlight);
 }
 


### PR DESCRIPTION
This is something that got spun out of https://github.com/nearform/node-clinic-bubbleprof/pull/107 - it was useful to validate that PR, and will be a useful feature, but has three problems which will be fixed in already-planned other work. I'm publishing it and putting it here because it might be useful for others' experiments etc. **Note: all the commits except the last one are from https://github.com/nearform/node-clinic-bubbleprof/pull/107, they'll be rebased out when it's merged.**


It adds buttons to each previous node's stack frames, allowing you to click on them and be taken to that node. This also helps the user understand that these previous frames relate to things earlier in the profile.

(again, I don't know why all my screenshots are coming out yellowish-green at the moment... I think my Mac must be ill. See 'select on diagram' on the right)
![image](https://user-images.githubusercontent.com/29628323/39303217-3360131a-494d-11e8-9a96-278c04987c1a.png)

It will become useful as a feature and merge-able when:
1. We add the 'clumping threshold' to stop 100% of the nodes in a layout being joined together when they are all equally small (currently if you use this feature to jump to a node in a layout like this, it gets stuck in an infinite loop)
2. We add hover boxes to sublayouts (coming shortly), which will then highlight which node in the new layout this refers to
3. We add animation on selecting a node. Currently the jump is unhelpfully disorientating unless you know a particular profile very well

This can probably be added once 1 and 2 are done; 3 will then massively improve the feature's usefulness.