### PR TITLE
Prevent underhanging svg when main svg is elongated and sublayout isn't

### DIFF
--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -401,9 +401,10 @@ svg.bubbleprof .link-outer {
   cursor: pointer;
 }
 
-/* Temporary partial fix to https://github.com/nearform/node-clinic-bubbleprof/issues/92 for sublayouts */
-section#sublayout:not(:last-child) {
-   display: none;
+/* Temporary fix to https://github.com/nearform/node-clinic-bubbleprof/issues/92 for sublayouts */
+section#sublayout:not(:last-child),
+svg#node-link-svg:not(:nth-last-child(2)) {
+  display: none;
 }
 
 /* Sidebar */


### PR DESCRIPTION
This is a quick fix to https://github.com/nearform/node-clinic-bubbleprof/issues/92 to make sure we don't run into any cases where an elongated main layout hangs underneath a non-elongated sublayout (echoing a similar quick fix for elongated sublayouts underhanging below non-elongated sub-sub-layouts).

Currently in our sample set we don't have any such cases, but it's something we've seen and it looks really bad. It will become impossible when we implement scale-to-fit, upon which this CSS will be removed.

So to confirm it works, without this patch take a sample and edit the SVG viewbox in dev tools to `viewBox="0 -500 1000 1500"`, to simulate an elongated main view (edit: Kamil has also published a branch, `more-width`, where some samples show this behaviour):

![image](https://user-images.githubusercontent.com/29628323/39318034-f1aa38d8-4974-11e8-8e04-0d19eeb133b5.png)

Then click on a node that brings up a non-elongated sublayout, which will demonstrate the bug:

![image](https://user-images.githubusercontent.com/29628323/39318069-07dc5b90-4975-11e8-9f8e-8c9183f5cbe9.png)

With this CSS fix the underhanging SVG is hidden:

![image](https://user-images.githubusercontent.com/29628323/39318105-20be512c-4975-11e8-9a6d-8777950f9f48.png)

It's not the sort of CSS we want long term, it's brittle, but it works for preventing a confusing bug in the short term while we work on the better long term alternative.