### PR TITLE
Neater labels: Fewer link time labels, drawn on line

### DIFF
--- a/visualizer/draw/svg-bubbles.js
+++ b/visualizer/draw/svg-bubbles.js
@@ -59,9 +59,9 @@ class Bubbles extends SvgContentGroup {
       })
 
     this.addCircles()
-    if (this.nodeType === 'ClusterNode') this.addTypeDonuts()
-
     this.addLabels()
+
+    if (this.nodeType === 'ClusterNode') this.addTypeDonuts()
   }
 
   getNodePosition (layoutNode) {

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -421,14 +421,14 @@ svg.bubbleprof .below-threshold-3 .name-label {
 svg.bubbleprof .time-label {
   font-size: 9pt;
   font-weight: bold;
-  paint-order: stroke fill;
-  stroke: var(--main-bg-color);
-  stroke-width: 4px;
-  stroke-opacity: 0.9;
 }
 
 svg.bubbleprof .link-wrapper .time-label {
   alignment-baseline: before-edge;
+  paint-order: stroke fill;
+  stroke: var(--main-bg-color);
+  stroke-width: 4px;
+  stroke-opacity: 0.9;
 }
 
 svg.bubbleprof .below-threshold-1.bubble-wrapper .time-label {


### PR DESCRIPTION
Another PR to make the labels display more neatly, this:

- Makes the thresholds for showing time labels on the links more strict
- Moves the labels onto the line so they add less clutter

Before:

![image](https://user-images.githubusercontent.com/29628323/39476767-1317f378-4d55-11e8-930a-d7fc2f73dd51.png)

![image](https://user-images.githubusercontent.com/29628323/39476777-229495cc-4d55-11e8-9050-0512939529c1.png)


After:

![image](https://user-images.githubusercontent.com/29628323/39476694-ccde06a4-4d54-11e8-967e-4f80182616d1.png)

![image](https://user-images.githubusercontent.com/29628323/39476719-e1141d66-4d54-11e8-80fb-89b587256c7a.png)
