### PR TITLE
Have bubble and link time labels match

### DIFF
--- a/visualizer/draw/svg-bubbles.js
+++ b/visualizer/draw/svg-bubbles.js
@@ -59,9 +59,9 @@ class Bubbles extends SvgContentGroup {
       })
 
     this.addCircles()
-    this.addLabels()
-
     if (this.nodeType === 'ClusterNode') this.addTypeDonuts()
+
+    this.addLabels()
   }
 
   getNodePosition (layoutNode) {

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -421,14 +421,14 @@ svg.bubbleprof .below-threshold-3 .name-label {
 svg.bubbleprof .time-label {
   font-size: 9pt;
   font-weight: bold;
-}
-
-svg.bubbleprof .link-wrapper .time-label {
-  alignment-baseline: before-edge;
   paint-order: stroke fill;
   stroke: var(--main-bg-color);
   stroke-width: 4px;
   stroke-opacity: 0.9;
+}
+
+svg.bubbleprof .link-wrapper .time-label {
+  alignment-baseline: before-edge;
 }
 
 svg.bubbleprof .below-threshold-1.bubble-wrapper .time-label {


### PR DESCRIPTION
Tiny commit to this which probably should have gone in https://github.com/nearform/node-clinic-bubbleprof/pull/113 - it applies the tweaks to how time labels on links display to the same time labels on bubbles. In practical terms, that means that in rare cases where you have a bubble that is a) just large enough to have a label but b) has a long label because the profile overall is large and the label just exceeds the width of the circle, it draws the label on top of the circle with a slight shadow so it is readable.

Before:

![image](https://user-images.githubusercontent.com/29628323/39478297-edb2676c-4d59-11e8-84bf-b44b35612c4a.png)


After: 

![image](https://user-images.githubusercontent.com/29628323/39478226-b5565892-4d59-11e8-8bfd-7d3aa4b1240c.png)