### PR TITLE
better http.connection.write naming

### DIFF
--- a/analysis/barrier/name-barrier-nodes.js
+++ b/analysis/barrier/name-barrier-nodes.js
@@ -180,6 +180,9 @@ function inferType (node, sysInfo) {
   for (let i = 0; i < node.frames.length; i++) {
     const f = node.frames.get(i)
     if (!f.isNodecore(sysInfo)) return null
+    if (f.typeName === 'ServerResponse' && f.functionName === 'write') {
+      return ['connection', 'write']
+    }
     if (f.typeName === 'ServerResponse' && f.functionName === 'end') {
       return ['connection', 'end']
     }


### PR DESCRIPTION
Before (using the series-services example that uses res.write)

![2018-05-03-134144_1920x1080_scrot](https://user-images.githubusercontent.com/376661/39574513-d66da70e-4ed7-11e8-8df9-acd17d7c03b9.png)

After

![2018-05-03-134135_1920x1080_scrot](https://user-images.githubusercontent.com/376661/39574519-db92610c-4ed7-11e8-9ab0-6de854f0c022.png)
