### PR TITLE
If clusterNode size is 1, treat as aggregateNode

### DIFF
--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -80,15 +80,29 @@ class BubbleprofUI extends EventEmitter {
   selectNode (layoutNode) {
     this.selectedNode = layoutNode
     const dataNode = layoutNode.node
-    if (dataNode.constructor.name === 'ShortcutNode') {
-      const targetLayoutNode = this.parentUI.layout.layoutNodes.get(dataNode.shortcutTo.id)
-      // TODO: replace with something better designed e.g. a back button for within sublayouts
-      this.deselectNode()
-      this.parentUI.createSubLayout(targetLayoutNode)
-    } else if (dataNode.constructor.name === 'AggregateNode') {
-      this.outputFrames(dataNode)
-    } else {
-      this.createSubLayout(layoutNode)
+    switch (dataNode.constructor.name) {
+      case 'ShortcutNode':
+        const targetLayoutNode = this.parentUI.layout.layoutNodes.get(dataNode.shortcutTo.id)
+        // TODO: replace with something better designed e.g. a back button for within sublayouts
+        this.deselectNode()
+        this.parentUI.createSubLayout(targetLayoutNode)
+        break
+
+      case 'AggregateNode':
+        this.outputFrames(dataNode)
+        break
+
+      case 'ClusterNode':
+        if (dataNode.nodes.size === 1) {
+          this.outputFrames(dataNode.nodes.values().next().value)
+        } else {
+          this.createSubLayout(layoutNode)
+        }
+        break
+
+      default:
+        this.createSubLayout(layoutNode)
+        break
     }
   }
 

--- a/visualizer/draw/hover-box.js
+++ b/visualizer/draw/hover-box.js
@@ -75,7 +75,12 @@ class HoverBox extends HtmlContent {
       this.d3BetweenTime.html(`<strong>${this.ui.formatNumber(dataNode.getBetweenTime())}\u2009ms</strong> aggregated delay from the previous bubble.`)
       this.d3WithinTime.html(`<strong>${this.ui.formatNumber(dataNode.getWithinTime())}\u2009ms</strong> aggregated delay within this bubble.`)
 
-      switch (nodeType) {
+      // If a clusterNode only contains one aggregate, no point clicking down into it, just give us the frames
+      const isIgnorableCluster = nodeType === 'ClusterNode' && layoutNode.node.nodes.size === 1
+      const clickableDataNode = isIgnorableCluster ? layoutNode.node.nodes.values().next().value : layoutNode.node
+      const clickableNodeType = clickableDataNode.constructor.name
+
+      switch (clickableNodeType) {
         case 'AggregateNode':
           this.d3ClickMessage.text('Click to display stack trace')
           this.d3Element.attr('name', 'aggregate-node')


### PR DESCRIPTION
A small tweak spun out from some larger work.

It's possible to have clusterNodes that only contain one aggregateNode. Before, you click on them, and are taken to a view with only one node in it, then you click that, and you get its frames.

This is a bit of a waste of users' time. This changes it so: 
 - if a clusterNode is selected and only contains one aggregateNode, it behaves as if that aggregate node was selected
 - if the user hovers over such a clusterNode, they get the "click to show frames" message as if it was an aggregateNode.

For example, before:

![image](https://user-images.githubusercontent.com/29628323/39590132-ec600622-4ef7-11e8-9e83-b634119493e5.png)

...then on click...

![image](https://user-images.githubusercontent.com/29628323/39590159-048acd7c-4ef8-11e8-9b69-2bbe6b70bdc4.png)

After:

![image](https://user-images.githubusercontent.com/29628323/39590250-4836b59a-4ef8-11e8-8cf0-00de206e35ba.png)

...then on click...

![image](https://user-images.githubusercontent.com/29628323/39590264-550aab0a-4ef8-11e8-816e-e4b17d3de8d3.png)

 