### PR TITLE
Update tap to version without security warnings in deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "snazzy": "^7.0.0",
     "standard": "^10.0.3",
     "startpoint": "^0.3.2",
-    "tap": "^10.7.2"
+    "tap": "^12.0.0"
   },
   "keywords": [],
   "license": "Apache-2.0",


### PR DESCRIPTION
NPM v6 was giving many security warnings. After flushing `node_modules` and re-installing, all the remaining warnings came down to outdated dependencies of `tap`. 

This PR brings `tap` up to a version that doesn't cause such warnings.