### PR TITLE
Add debugMode for inspecting sourceNodes and tests 

### DIFF
--- a/test/visualizer-data-dataset.test.js
+++ b/test/visualizer-data-dataset.test.js
@@ -5,7 +5,7 @@ const DataSet = require('../visualizer/data/dataset.js')
 const acmeairJson = require('./visualizer-util/sampledata-acmeair.json')
 
 test('Visualizer dataset - fake json', function (t) {
-  const dataSet = loadData(fakeJson)
+  const dataSet = loadData({ debugMode: true }, fakeJson)
 
   t.equals(dataSet.clusterNodes.size, 2)
   t.equals(dataSet.aggregateNodes.size, 2)
@@ -24,14 +24,14 @@ test('Visualizer data - DataSet - empty data file', function (t) {
 
 test('Visualizer data - DataSet - invalid settings', function (t) {
   t.throws(() => {
-    loadData({ map: () => {} }, { averaging: 'mode' })
+    loadData({ averaging: 'mode' }, { map: () => {} })
   }, new Error('Invalid key "mode" passed, valid types are: mean, median, sum'))
 
   t.end()
 })
 
 test('Visualizer data - DataSet - access invalid node id', function (t) {
-  const dataSet = loadData(fakeJson)
+  const dataSet = loadData({ debugMode: true }, fakeJson)
 
   t.equal(dataSet.getByNodeType('ClusterNode', 'foo'), undefined)
 
@@ -52,7 +52,7 @@ test('Visualizer dataset - wallTime from real sample data', function (t) {
 })
 
 test('Visualizer data - invalid calls to dataSet.wallTime.getSegments', function (t) {
-  const { wallTime } = loadData(acmeairJson)
+  const { wallTime } = loadData({ debugMode: true }, acmeairJson)
 
   t.throws(() => {
     wallTime.getSegments(6782000, 6786000)

--- a/test/visualizer-data-node.test.js
+++ b/test/visualizer-data-node.test.js
@@ -55,7 +55,7 @@ function validateData (dataSet) {
 }
 
 test('Visualizer data - data nodes - examples/slow-io sample json', function (t) {
-  const dataSet = loadData(slowioJson)
+  const dataSet = loadData({ debugMode: true }, slowioJson)
 
   t.equals(dataSet.settings.averaging, 'mean')
 
@@ -66,7 +66,7 @@ test('Visualizer data - data nodes - examples/slow-io sample json', function (t)
 })
 
 test('Visualizer data - data nodes - acmeair sample json', function (t) {
-  const dataSet = loadData(acmeairJson, { averaging: 'median' })
+  const dataSet = loadData({ debugMode: true, averaging: 'median' }, acmeairJson)
 
   t.equals(dataSet.settings.averaging, 'median')
 

--- a/test/visualizer-layout-connections.test.js
+++ b/test/visualizer-layout-connections.test.js
@@ -17,7 +17,7 @@ const fakeScale = {
 }
 
 test('Visualizer layout - scale - calculates visible circle radius based on within of the node and the scale', function (t) {
-  const dataSet = loadData(slowioJson)
+  const dataSet = loadData({ debugMode: true }, slowioJson)
   const layout = generateLayout(dataSet)
 
   const parentLayoutNode = layout.layoutNodes.get(1)
@@ -37,7 +37,7 @@ test('Visualizer layout - scale - calculates visible circle radius based on with
 })
 
 test('Visualizer layout - scale - calculates visible line length based on between of the child node and the scale', function (t) {
-  const dataSet = loadData(slowioJson)
+  const dataSet = loadData({ debugMode: true }, slowioJson)
   const layout = generateLayout(dataSet)
 
   const parentLayoutNode = layout.layoutNodes.get(1)
@@ -52,7 +52,7 @@ test('Visualizer layout - scale - calculates visible line length based on betwee
 })
 
 test('Visualizer layout - scale - calculates distance between centers', function (t) {
-  const dataSet = loadData(slowioJson)
+  const dataSet = loadData({ debugMode: true }, slowioJson)
   const layout = generateLayout(dataSet)
 
   const parentLayoutNode = layout.layoutNodes.get(1)

--- a/test/visualizer-layout-node-allocation.test.js
+++ b/test/visualizer-layout-node-allocation.test.js
@@ -23,7 +23,7 @@ test('Visualizer layout - node allocation - all assigned leaf units are proporti
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -58,7 +58,7 @@ test('Visualizer layout - node allocation - three-sided space segments depend on
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -85,7 +85,7 @@ test('Visualizer layout - node allocation - blocks do not overlap or exceed allo
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -120,7 +120,7 @@ test('Visualizer layout - node allocation - xy positions of leaves are allocated
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -149,7 +149,7 @@ test('Visualizer layout - node allocation - xy positions of nodes are allocated 
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -225,7 +225,7 @@ test('Visualizer layout - node allocation - can handle subsets', function (t) {
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   t.ok(dataSet)
   const subset = [6, 7, 8].map(nodeId => dataSet.clusterNodes.get(nodeId))
   const layout = new Layout({ dataNodes: subset }, settings)
@@ -281,7 +281,7 @@ test('Visualizer layout - node allocation - can handle collapsets', function (t)
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 501 - 3]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -336,7 +336,7 @@ test('Visualizer layout - node allocation - can handle collapsets with clumpy le
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 501 - 3]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)

--- a/test/visualizer-layout-positioning.test.js
+++ b/test/visualizer-layout-positioning.test.js
@@ -19,7 +19,7 @@ test('Visualizer layout - positioning - mock topology', function (t) {
     ['1.2.3.4', 150],
     ['1.9', 50]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   t.ok(dataSet)
 
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
@@ -58,7 +58,7 @@ test('Visualizer layout - positioning - pyramid - simple', function (t) {
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
 
   const positioning = layout.positioning
@@ -80,7 +80,7 @@ test('Visualizer layout - positioning - pyramid - gaps', function (t) {
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
 
   const positioning = layout.positioning
@@ -108,7 +108,7 @@ test('Visualizer layout - positioning - pyramid - clumping tiny together with lo
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
 
   const positioning = layout.positioning
@@ -148,7 +148,7 @@ test('Visualizer layout - positioning - pyramid - example in docs', function (t)
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
 
   const positioning = layout.positioning
@@ -168,7 +168,7 @@ test('Visualizer layout - positioning - debugInspect', function (t) {
     ['1.8', 100 - 1]
   ]
 
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0, svgDistanceFromEdge: 0 })
 
   const positioning = layout.positioning
@@ -199,7 +199,7 @@ test('Visualizer layout - positioning - pyramid - can handle subsets', function 
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const subset = [...dataSet.clusterNodes.values()].filter(node => node.id !== 1 && node.id !== 2)
   const layout = new Layout({ dataNodes: subset })
   layout.generate()
@@ -224,7 +224,7 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets', functi
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] })
   layout.processHierarchy({ collapseNodes: true })
   // Arbitrary Map order being issue here
@@ -249,7 +249,7 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets with clu
   ]
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] })
   layout.processHierarchy({ collapseNodes: true })
   // Arbitrary Map order being issue here

--- a/test/visualizer-layout-scale.test.js
+++ b/test/visualizer-layout-scale.test.js
@@ -26,7 +26,7 @@ test('Visualizer layout - scale - calculates prescale based on longest', functio
     ['1.5', svgHeight / 2],
     ['1.2.6', 1]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.ok(layout.scale.prescaleFactor < 2.00 && layout.scale.prescaleFactor > 1.99)
@@ -38,7 +38,7 @@ test('Visualizer layout - scale - calculates scalable line length', function (t)
   const topology = [
     ['1.2', svgHeight]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.ok(isNumber(layout.scale.scaleFactor))
@@ -52,7 +52,7 @@ test('Visualizer layout - scale - calculates scalable circle radius based on len
   const topology = [
     ['1.2', svgHeight]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.ok(isNumber(layout.scale.scaleFactor))
@@ -67,7 +67,7 @@ test('Visualizer layout - scale - demagnifies large shortest', function (t) {
     ['1.2', svgWidth],
     ['1.3', svgWidth * 0.9]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'shortest')
@@ -80,7 +80,7 @@ test('Visualizer layout - scale - demagnifies large longest and stretches height
   const topology = [
     ['1.2.3.4.5.6.7', svgHeight * 3]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'longest')
@@ -94,7 +94,7 @@ test('Visualizer layout - scale - folds small layouts', function (t) {
   const topology = [
     ['1.2', 1]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   const nodesCount = 2
@@ -110,7 +110,7 @@ test('Visualizer layout - scale - constrained longest superseeds other weights',
     ['1.6', svgWidth * 1.51],
     ['1.7', svgWidth * 1.5]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
 
@@ -130,7 +130,7 @@ test('Visualizer layout - scale - constrained longest superseeds other weights (
     ['1.6', svgWidth * 0.5],
     ['1.7', svgWidth * 0.5]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
 
@@ -147,7 +147,7 @@ test('Visualizer layout - scale - demagnifies large diameter (width)', function 
   const topology = [
     ['1.2.3.4.5', 1]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.layoutNodes.get(2).stem.raw.ownDiameter = svgWidth
   layout.updateScale()
@@ -161,7 +161,7 @@ test('Visualizer layout - scale - demagnifies large diameter (height)', function
   const topology = [
     ['1.2.3.4.5.6.7', 1]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const inputHeight = (250 + 30 + 30) * (1 / 1.5)
   const layout = generateLayout(dataSet, Object.assign({}, settings, { svgHeight: inputHeight }))
   layout.layoutNodes.get(2).stem.raw.ownDiameter = 500
@@ -178,7 +178,7 @@ test('Visualizer layout - scale - demagnifies large q50', function (t) {
     ['1.2', (svgWidth / 0.71) + 10],
     ['1.4', 1]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'q50 1-1-sqrt(2) triangle')
@@ -194,7 +194,7 @@ test('Visualizer layout - scale - demagnifies large q25', function (t) {
     ['1.4', (svgWidth / 0.8) + 10],
     ['1.5', 1]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'q25 4-3-5 triangle')
@@ -211,7 +211,7 @@ test('Visualizer layout - scale - demagnifies large q75', function (t) {
     ['1.4', 1],
     ['1.6', 1]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'q75 3-4-5 triangle')
@@ -224,7 +224,7 @@ test('Visualizer layout - scale - magnifies tiny longest', function (t) {
   const topology = [
     ['1.2.3.4.5', svgHeight / 2]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'longest')
@@ -245,7 +245,7 @@ test('Visualizer layout - scale - can handle subsets', function (t) {
     ['1.2.3.4.5.18', svgWidth * 0.34]
   ]
 
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const subset = [...dataSet.clusterNodes.values()].filter(node => node.id !== 1 && node.id !== 2)
   const layout = new Layout({ dataNodes: subset })
   layout.generate()
@@ -259,7 +259,7 @@ test('Visualizer layout - scale - demagnifies when absolutes exceed available sp
   const topology = [
     ['1.2.3.4.5.6.7.8.9.10.11', 1]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, { svgWidth: 100, svgHeight: 100, svgDistanceFromEdge: 5, labelMinimumSpace: 20, lineWidth: 30, collapseNodes: false })
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'longest')

--- a/test/visualizer-layout-stems.test.js
+++ b/test/visualizer-layout-stems.test.js
@@ -8,7 +8,7 @@ const generateLayout = require('../visualizer/layout/index.js')
 const { mockTopology } = require('./visualizer-util/fake-topology.js')
 
 test('Visualizer layout - stems - calculates between and diameter based on stats', function (t) {
-  const dataSet = loadData(slowioJson)
+  const dataSet = loadData({ debugMode: true }, slowioJson)
   const layout = generateLayout(dataSet)
 
   const layoutNode = layout.layoutNodes.get(16)
@@ -20,7 +20,7 @@ test('Visualizer layout - stems - calculates between and diameter based on stats
 })
 
 test('Visualizer layout - stems - calculates length based on ancestors and scale', function (t) {
-  const dataSet = loadData(slowioJson)
+  const dataSet = loadData({ debugMode: true }, slowioJson)
   const layout = generateLayout(dataSet, { labelMinimumSpace: 2, lineWidth: 3 })
 
   const stem = layout.layoutNodes.get(16).stem
@@ -51,7 +51,7 @@ test('Visualizer layout - stems - identifies leaves', function (t) {
     ['1.2.8', 1]
   ]
 
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
 
   t.deepEqual(layout.layoutNodes.get(1).stem.leaves.ids, [4, 5, 7, 8, 9])

--- a/test/visualizer-layout.test.js
+++ b/test/visualizer-layout.test.js
@@ -27,7 +27,7 @@ test('Visualizer layout - builds sublayout from connection', function (t) {
   const topology = [
     ['1.2.3.4.5', 100]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const initialDataNodes = [...dataSet.clusterNodes.values()]
   const uncollapsedSettings = Object.assign({ collapseNodes: false }, settings)
   const initialLayout = new Layout({ dataNodes: initialDataNodes }, uncollapsedSettings)
@@ -49,7 +49,7 @@ test('Visualizer layout - collapse - collapses children and parents linearly (ex
   const topology = [
     ['1.2.3.4.5', 100]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   const layout = new Layout({ dataNodes }, settings)
@@ -71,7 +71,7 @@ test('Visualizer layout - collapse - collapses children and parents linearly wit
   const topology = [
     ['1.2.3.4.5.6.7', 100]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   dataSet.clusterNodes.get(4).stats.async.between = 100 // make 4 long
@@ -95,7 +95,7 @@ test('Visualizer layout - collapse - collapses children and parents linearly unt
     ['1.2.3.4.5', 1],
     ['1.2.3.4.6', 1]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1000 // make root long
   const layout = new Layout({ dataNodes }, settings)
@@ -125,7 +125,7 @@ test('Visualizer layout - collapse - collapses branches at stem', function (t) {
     ['1.2.5.6', 100],
     ['1.2.7.8', 100]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(2).stats.async.between = 100 // make 2 long
   dataSet.clusterNodes.get(5).stats.async.between = 100 // make 5 long
@@ -153,7 +153,7 @@ test('Visualizer layout - collapse - collapses both siblings and parents (except
     ['1.2.3.4', 100],
     ['1.2.5.6', 100]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   const layout = new Layout({ dataNodes }, settings)
@@ -180,7 +180,7 @@ test('Visualizer layout - collapse - collapses children and parents while ignori
     ['1.2.3.4', 100],
     ['1.2.5.6', 100]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   dataSet.clusterNodes.get(5).stats.async.between = 100 // make 5 long
@@ -208,7 +208,7 @@ test('Visualizer layout - collapse - collapses subset with missing root (except 
     ['1.2.3.4.5', 100],
     ['1.6.7.8.9', 100]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   dataSet.clusterNodes.get(8).stats.async.within = 100 // make 8 long
   const subset = [2, 3, 4, 5, 6, 7, 8, 9].map(nodeId => dataSet.clusterNodes.get(nodeId))
   const layout = new Layout({ dataNodes: subset }, settings)
@@ -235,7 +235,7 @@ test('Visualizer layout - collapse - collapses subset with missing leaves (excep
     ['1.2.3.4.5', 100],
     ['1.2.6.7.8', 100]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   dataSet.clusterNodes.get(7).stats.async.within = 100 // make 7 wide
   dataSet.clusterNodes.get(7).stats.async.between = 100 // make 7 long
@@ -275,7 +275,7 @@ test('Visualizer layout - collapse - complex example', function (t) {
     ['1.3.10.11', 1],
     ['1.3.10.12.13', 1]
   ]
-  const dataSet = loadData(mockTopology(topology))
+  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   dataSet.clusterNodes.get(2).stats.async.within = 100 // make 2 long

--- a/visualizer/data/data-node.js
+++ b/visualizer/data/data-node.js
@@ -187,11 +187,18 @@ class AggregateNode extends DataNode {
     this.typeCategory = typeCategory
     this.typeSubCategory = typeSubCategory
 
+    const debugMode = this.dataSet.settings.debugMode
+
     // This loop runs thousands+ times, unbounded and scales with size of profile. Optimize for browsers
     const sourcesLength = node.sources.length
+    if (debugMode) this.sources = new Array(sourcesLength)
+
     for (var i = 0; i < sourcesLength; i++) {
-      this.dataSet.sourceNodes.push(new SourceNode(node.sources[i], this))
+      const sourceNode = new SourceNode(node.sources[i], this)
+
+      if (debugMode) this.sources[i] = sourceNode
     }
+    if (debugMode) this.dataSet.sourceNodes = this.dataSet.sourceNodes.concat(this.sources)
 
     this.dataSet.aggregateNodes.set(this.aggregateId, this)
   }

--- a/visualizer/data/dataset.js
+++ b/visualizer/data/dataset.js
@@ -13,7 +13,8 @@ class DataSet {
     const defaultSettings = {
       averaging: 'mean', // to be applied to callbackEvents within a sourceNode
       quantileRange: 99, // set null to keep all outliers
-      idleOnly: false // if true, discounts async delays while sync process blocks event loop
+      idleOnly: false, // if true, discounts async delays while sync process blocks event loop
+      debugMode: false // if true, keeps sourceNodes in memory and exposes dataSet and Layout to window
     }
 
     settings = Object.assign(defaultSettings, settings)
@@ -58,7 +59,7 @@ class DataSet {
     // Array of CallbackEvents is temporary for calculating stats on other nodes
     this.callbackEvents = new AllCallbackEvents(this.wallTime) // CallbackEvents are created and pushed within SourceNode constructor
     // Source, Aggregate and Cluster Node maps persist in memory throughout
-    this.sourceNodes = [] // SourceNodes are created from and pushed to this array in AggregateNode constructor
+    if (this.settings.debugMode) this.sourceNodes = [] // SourceNodes are created from and pushed to this array in AggregateNode constructor
     this.aggregateNodes = new Map() // AggregateNodes are created from ClusterNode constructor and set in their own constructor
     this.clusterNodes = new Map(
       data.map((node) => [node.clusterId, new ClusterNode(node, this)])

--- a/visualizer/data/index.js
+++ b/visualizer/data/index.js
@@ -5,7 +5,7 @@ const data = require('../data.json') // base64 encoded source file
 const DataSet = require('./dataset.js')
 
 // 'json = data' optional arg allows json to be passed in for browserless tests
-function loadData (json = data, settings = {}) {
+function loadData (settings = {}, json = data) {
   const dataSet = new DataSet(json, settings)
   dataSet.processData()
   return dataSet

--- a/visualizer/main.js
+++ b/visualizer/main.js
@@ -11,13 +11,17 @@ setTimeout(() => {
   const loadData = require('./data/index.js')
   const generateLayout = require('./layout/index.js')
 
-  const dataSet = loadData()
-  window.data = dataSet
-  console.log('data is exposed on window.data')
+  const dataSet = loadData({ debugMode: false })
+  if (dataSet.settings.debugMode) {
+    window.data = dataSet
+    console.log('data is exposed on window.data')
+  }
 
   const layout = generateLayout(dataSet, Object.assign({ collapseNodes: true }, ui.getSettingsForLayout()))
-  window.layout = layout
-  console.log('layout is exposed on window.layout')
+  if (dataSet.settings.debugMode) {
+    window.layout = layout
+    console.log('layout is exposed on window.layout')
+  }
 
   /* istanbul ignore next */
   ui.setData(layout)


### PR DESCRIPTION
SourceNodes (of which there usually many thousands) aren't needed after using them to generate CallbackEvents then using and discarding those to add stats to aggregateNodes and clusterNodes; but it can be useful to look up sourceNodes for debugging purposes, and to check them in tests. 

Likewise, we're currently exposing `dataSet` and `layout` objects in the browser console, which is very useful for debugging, but maybe doesn't make sense for end users.

This PR only keeps references to sourceNodes in memory, and only attaches `dataSet` and `layout` objects to the window and advertises them in console.log, if a `debugMode` setting is flipped from `false` to `true`. 

We don't need to optimise more right now, but this does also give a nice performance boost of around ~8% on the UI code (data/layout/draw) - seems to be bigger savings on larger profiles, which makes sense. It also gives us more options for optimising further if we need to in future.

![image](https://user-images.githubusercontent.com/29628323/40378096-78ae1d2a-5dea-11e8-87ec-f198b03f3a8f.png)
