### PR TITLE
Position hover box vertically unless necessary

### DIFF
--- a/visualizer/draw/hover-box.js
+++ b/visualizer/draw/hover-box.js
@@ -40,16 +40,9 @@ class HoverBox extends HtmlContent {
     })
   }
 
-  positionWithSidebar (nodePosition, responsiveScaleFactor, svgContainerBounds, bBox) {
+  positionSidewards (nodePosition, responsiveScaleFactor, svgContainerBounds, bBox) {
     const { width, height } = bBox
     const top = nodePosition.y * responsiveScaleFactor
-    const titleBlockHeight = this.d3TitleBlock.node().getBoundingClientRect().height
-
-    if (top + titleBlockHeight > svgContainerBounds.height) {
-      // Place hover box above to stop overflow below edge of page
-      this.positionWithoutSidebar(nodePosition, responsiveScaleFactor, svgContainerBounds, bBox)
-      return
-    }
 
     const left = nodePosition.x * responsiveScaleFactor
     const horizontalFlip = left + width > window.innerWidth
@@ -62,7 +55,7 @@ class HoverBox extends HtmlContent {
     this.d3Element.classed('use-vertical-arrow', false)
   }
 
-  positionWithoutSidebar (nodePosition, responsiveScaleFactor, svgContainerBounds, bBox) {
+  position (nodePosition, responsiveScaleFactor, svgContainerBounds, bBox) {
     const { width, height } = bBox
     const verticalArrowPadding = 12
     const initialTop = nodePosition.y * responsiveScaleFactor + verticalArrowPadding
@@ -83,6 +76,12 @@ class HoverBox extends HtmlContent {
       const titleBlockHeight = this.d3TitleBlock.node().getBoundingClientRect().height
       adjustedTop -= titleBlockHeight + verticalArrowPadding * 2
       verticalFlip = true
+    }
+
+    // On short windows with no space above or below
+    if (adjustedTop < 0) {
+      this.positionSidewards(nodePosition, responsiveScaleFactor, svgContainerBounds, bBox)
+      return
     }
 
     this.d3Element.style('top', adjustedTop + 'px')
@@ -119,13 +118,8 @@ class HoverBox extends HtmlContent {
       // Ensure off-bottom class is not applied before calculating if it's needed
       this.d3Element.classed('off-bottom', false)
       const bBox = this.d3Element.node().getBoundingClientRect()
-      const arrowSpacing = 12
 
-      if (window.innerWidth > bBox.width * 2 + arrowSpacing && window.innerHeight < window.innerWidth) {
-        this.positionWithSidebar(nodePosition, responsiveScaleFactor, svgContainerBounds, bBox)
-      } else {
-        this.positionWithoutSidebar(nodePosition, responsiveScaleFactor, svgContainerBounds, bBox)
-      }
+      this.position(nodePosition, responsiveScaleFactor, svgContainerBounds, bBox)
 
       const nodeType = layoutNode.node.constructor.name
       const dataNode = nodeType === 'ShortcutNode' ? layoutNode.node.shortcutTo : layoutNode.node


### PR DESCRIPTION
Another small PR spun out from the plot operations by time work.

Previously, in landscape view, hover boxes default to be left or right of what they are pointing to. This means they sometimes overlap the right hand side bar:

![image](https://user-images.githubusercontent.com/29628323/40658058-de591466-6341-11e8-82e0-5e2e2ad16c52.png)

This is increasingly a problem as we add more interactive features to the right hand side bar.

This PR switches the default to above or below, same as portrait view, keeping the hover box off the side bar:

![image](https://user-images.githubusercontent.com/29628323/40658140-26fd5b96-6342-11e8-8e50-f23cf069ccb8.png)

...unless we're in a position in an abnormally short window where there's no space either above or below, in which case the old left or right orientation is used in preference to spilling off the screen:

![image](https://user-images.githubusercontent.com/29628323/40658203-62712478-6342-11e8-8f59-3a28df35df5d.png)
