### PR TITLE
Only create <main> element once

### DIFF
--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -262,10 +262,11 @@ class BubbleprofUI extends EventEmitter {
   // so that browser paint etc can happen around the same time, minimising reflows
   initializeElements () {
     const d3Body = d3.select('body')
+    const d3Main = d3.select('main')
     d3Body.classed('initialized', true)
     d3Body.attr('data-view-mode', this.settings.viewMode)
 
-    this.mainContainer.d3Element = d3Body.append('main')
+    this.mainContainer.d3Element = d3Main.size() ? d3Main : d3Body.append('main')
     this.mainContainer.d3ContentWrapper = this.mainContainer.d3Element
 
     // TODO: try replacing with .emit('initializeElements')


### PR DESCRIPTION
A small bug I noticed when trying to debug another bug. Turned out to be unrelated, but still worth fixing.

Previously, a new empty `<main>` element got added to the page each time a sublayout was created. This stops that, so there's only ever one `<main>` element on the page.