### PR TITLE
Prevent empty scrollbars appearing and flashing

### DIFF
--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -51,6 +51,12 @@ html, body {
 
 body {
   background: var(--main-bg-color);
+
+  /* To resolve inconsistent browser issues:
+   * - Chrome flashes an empty y scrollbar inconstently on some events in sublayouts
+   * - Firefox adds an empty x scrollbar to sublayouts */
+  overflow-y: scroll;
+  overflow-x: hidden;
 }
 
 /* Global Typography */


### PR DESCRIPTION
We found some strange and inconsistent browser issues with scrollbars in testing another PR:

- On recent versions of Chrome, if scrollbars are set to visible (default on Windows/Linux, option on Mac), often inside sublayouts hovering over a node causes an empty vertical scrollbar to appear, which in turn changes the layout of the page, moving the item being moused over, potentially causing a flashing loop. The scrollbar is usually empty and no elements on the page appear to actually change height. It also happens in some strange cases, such as moving the mouse on and off some elements in the header
- This doesn't happen in Firefox in the same way, but Firefox has an issue where an empty horizontal scrollbar is visible on sublayouts but not main layouts.

After some thorough investigation there's no clear reason why these should appear like this, as nothing seems to actually increase in size when the scrollbars appear: appears to be browser quirks that might be fixed in future versions. So, for now, applying this CSS stops these browser quirks from annoying the user.
