### PR TITLE
Stop hover box vertical arrow obstructing click

### DIFF
--- a/visualizer/draw/hover-box.js
+++ b/visualizer/draw/hover-box.js
@@ -150,11 +150,13 @@ class HoverBox extends HtmlContent {
           this.d3Element.attr('name', 'cluster-node')
           break
       }
-      this.d3TitleBlock.on('click', () => {
+      const clickHandler = () => {
         d3.event.stopPropagation()
         this.ui.highlightNode(null)
         this.ui.selectNode(layoutNode)
-      })
+      }
+      this.d3TitleBlock.on('click', clickHandler)
+      this.d3VerticalArrow.on('click', clickHandler)
     }
   }
 }

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -719,6 +719,7 @@ body[data-highlight-party='nodecore'] svg .party-root .by-variable {
 .hover-box .vertical-arrow {
   display: none;
   margin-left: 6px;
+  cursor: pointer;
 }
 
 .hover-box.use-vertical-arrow {


### PR DESCRIPTION
Fix for a small but annoying bug - the vertical arrow in the hover box, pointing to a node, wasn't clickable whereas the horizontal one was a pseudoelement therefore shared the same click event.

This meant that sometimes when you try to click on a node you're hovering over, it doesn't work because the arrow is in the way. This fixes that, giving the arrow the same click event.