### PR TITLE
Only highlight colours on hover from key

### DIFF
--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -616,16 +616,16 @@ body.spiderweb-layout svg.bubbleprof .link-inner {
   opacity: 0.5;
 }
 
-body[data-highlight-type='files-streams'] svg .type-files-streams,
-body[data-highlight-type='networks'] svg .type-networks,
-body[data-highlight-type='crypto'] svg .type-crypto,
-body[data-highlight-type='timing-promises'] svg .type-timing-promises,
-body[data-highlight-type='other'] svg .type-other,
+body[data-highlight-type='files-streams'] #node-link svg:not(:hover) .type-files-streams,
+body[data-highlight-type='networks'] #node-link svg:not(:hover) .type-networks,
+body[data-highlight-type='crypto'] #node-link svg:not(:hover) .type-crypto,
+body[data-highlight-type='timing-promises'] #node-link svg:not(:hover) .type-timing-promises,
+body[data-highlight-type='other'] #node-link svg:not(:hover) .type-other,
 
-body[data-highlight-party='user'] svg .party-user .by-variable,
-body[data-highlight-party='external'] svg .party-external .by-variable ,
-body[data-highlight-party='nodecore'] svg .party-nodecore .by-variable,
-body[data-highlight-party='nodecore'] svg .party-root .by-variable {
+body[data-highlight-party='user'] #node-link svg:not(:hover) .party-user .by-variable,
+body[data-highlight-party='external'] #node-link svg:not(:hover) .party-external .by-variable ,
+body[data-highlight-party='nodecore'] #node-link svg:not(:hover) .party-nodecore .by-variable,
+body[data-highlight-party='nodecore'] #node-link svg:not(:hover) .party-root .by-variable {
   /* !important overrides the stroke-width style set from js line width settings */
   stroke-width: 4px !important;
 }


### PR DESCRIPTION
Another fix for an annoying issue that came up while investigating another bug.

When we highlight a colour, it highlights the key label for that colour, and everything else of the same colour. Highlighting everything else of the same colour is potentially confusing and unhelpful when we're hovering over a node in the main diagram because it makes it harder to see specifically which node is in focus.

This keeps the highlight when we mouseover a key in the top panel:

![image](https://user-images.githubusercontent.com/29628323/40735807-0e12f9b8-6434-11e8-81de-26bbe8d46222.png)

...but only highlights the key (e.g. "Networks") on hovering over a node on the diagram:

![image](https://user-images.githubusercontent.com/29628323/40735765-ed8d9860-6433-11e8-8a03-c94d0cb50b1e.png)
