### PR TITLE
Isolate node-link-specific logic in hover box

### DIFF
--- a/visualizer/draw/breadcrumb-panel.js
+++ b/visualizer/draw/breadcrumb-panel.js
@@ -59,7 +59,7 @@ class BreadcrumbPanel extends HtmlContent {
 
     document.onkeydown = (e) => {
       if (e.keyCode === 27) {
-          // ESC button
+        // ESC button
         this.topmostUI.clearSublayout()
       }
     }

--- a/visualizer/draw/hover-box.js
+++ b/visualizer/draw/hover-box.js
@@ -29,7 +29,6 @@ class HoverBox extends HtmlContent {
 
     if (this.contentProperties.type === 'node-link') {
       this.nodeLinkElements()
-      return
     }
   }
 


### PR DESCRIPTION
This is another small PR spun out from the async operations chart PR to stop it getting too big.

It's a refactor, so nothing should change in the UI. From my testing, this seems to be the case. I'm posting this in isolation partly so it's easier to test and confirm that indeed nothing does change.

What this does, is separate out logic in the hover boxes that is specific to the main hover box on the node link diagram, from logic that is generic to hover boxes in general. 

This allows us to use the same code to add simpler hover boxes to other charts. There will be a 'tooltip' type added to the async operations over time chart, and further down the line (post launch) I'd like to add one to the interactive keys along the top, telling a user what is in the 'Networks' category, for example, or what precisely we mean by "Your code" and how it is relevant, which this should make easy.