### PR TITLE
Add html-content-types to prevent circular require()s

### DIFF
--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -1,12 +1,11 @@
 'use strict'
 
-const HtmlContent = require('./html-content.js')
 const d3 = require('./d3-subset.js')
 const debounce = require('lodash/debounce')
 const EventEmitter = require('events')
+const htmlContentTypes = require('./html-content-types.js')
 const Layout = require('../layout/layout.js')
-const SvgContainer = require('./svg-container.js')
-const HoverBox = require('./hover-box.js')
+const { validateKey } = require('../validation.js')
 
 class BubbleprofUI extends EventEmitter {
   constructor (sections = [], settings = {}, appendTo, parentUI = null) {
@@ -39,12 +38,17 @@ class BubbleprofUI extends EventEmitter {
     this.sections = new Map()
 
     for (const sectionName of sections) {
-      this.sections.set(sectionName, new HtmlContent(appendTo, {
+      this.sections.set(sectionName, new htmlContentTypes.HtmlContent(appendTo, {
         htmlElementType: 'section',
         id: sectionName,
         classNames: this.settings.classNames
       }, this))
     }
+  }
+
+  getContentClass (className) {
+    validateKey(className, Object.keys(htmlContentTypes))
+    return htmlContentTypes[className]
   }
 
   getNodeLinkSection () {
@@ -98,10 +102,10 @@ class BubbleprofUI extends EventEmitter {
       sublayout.addCollapseControl()
       const closeBtn = sublayout.addContent(undefined, { classNames: 'close-btn' })
 
-      const sublayoutSvg = sublayout.addContent(SvgContainer, {id: 'sublayout-svg', svgBounds: {}})
+      const sublayoutSvg = sublayout.addContent('SvgContainer', {id: 'sublayout-svg', svgBounds: {}})
       sublayoutSvg.addBubbles({nodeType: 'AggregateNode'})
       sublayoutSvg.addLinks({nodeType: 'AggregateNode'})
-      sublayout.addContent(HoverBox, {svg: sublayoutSvg})
+      sublayout.addContent('HoverBox', {svg: sublayoutSvg})
 
       uiWithinSublayout.initializeElements()
 

--- a/visualizer/draw/hover-box.js
+++ b/visualizer/draw/hover-box.js
@@ -9,8 +9,10 @@ class HoverBox extends HtmlContent {
     super(d3Container, Object.assign({
       type: 'node-link'
     }, contentProperties))
-    if (!this.contentProperties.svg) throw new Error('HoverBox requires contentProperties.svg to be defined')
     validateKey(this.contentProperties.type, ['node-link', 'tool-tip'])
+    if (this.contentProperties.type === 'node-link' && !this.contentProperties.svg) {
+      throw new Error('Node-link HoverBox requires contentProperties.svg to be defined')
+    }
 
     this.isHidden = true
   }

--- a/visualizer/draw/html-content-types.js
+++ b/visualizer/draw/html-content-types.js
@@ -1,0 +1,16 @@
+'use strict'
+
+// This lookup object of HTML content types is necessary to prevent circular dependencies
+// e.g. if an A contains a B which contains an A
+module.exports = {
+  // Parent class, for generic HTML content with optional collapse, load indicator, etc
+  HtmlContent: require('./html-content.js'),
+
+  // Sub classes which extend HtmlContent
+  BreadcrumbPanel: require('./breadcrumb-panel.js'),
+  Frames: require('./frames.js'),
+  HoverBox: require('./hover-box.js'),
+  InteractiveKey: require('./interactive-key.js'),
+  Lookup: require('./lookup.js'),
+  SvgContainer: require('./svg-container.js')
+}

--- a/visualizer/draw/html-content.js
+++ b/visualizer/draw/html-content.js
@@ -28,7 +28,8 @@ class HtmlContent {
     this.contentIds = []
   }
 
-  addContent (ContentClass = HtmlContent, contentProperties = {}, prepend = false) {
+  addContent (className = 'HtmlContent', contentProperties = {}, prepend = false) {
+    const ContentClass = this.ui.getContentClass(className)
     const item = new ContentClass(this, contentProperties)
     const identifier = uniqueMapKey(contentProperties.id || ContentClass.constructor.name, this.content)
 

--- a/visualizer/draw/index.js
+++ b/visualizer/draw/index.js
@@ -1,13 +1,7 @@
 'use strict'
 
 const BubbleprofUI = require('./bubbleprof-ui.js')
-const HoverBox = require('./hover-box.js')
-const InteractiveKey = require('./interactive-key.js')
-const SvgContainer = require('./svg-container.js')
 const staticKeyHtml = require('./static-key.js')
-const Frames = require('./frames.js')
-const Lookup = require('./lookup.js')
-const BreadcrumbPanel = require('./breadcrumb-panel.js')
 
 function drawOuterUI () {
   // Initial DOM drawing that is independent of data
@@ -21,47 +15,47 @@ function drawOuterUI () {
   const partyKeyPanel = highlightBar.addContent(undefined, { classNames: 'panel', htmlContent: '<label>Party:</label>' })
   const typeKeyPanel = highlightBar.addContent(undefined, { classNames: 'panel', htmlContent: '<label>Type:</label>' })
   const breadcrumbBar = header.addContent(undefined, { classNames: 'header-bar breadcrumb-bar', htmlContent: '<div></div>' })
-  breadcrumbBar.addContent(BreadcrumbPanel, { classNames: 'panel', originalUI: ui })
+  breadcrumbBar.addContent('BreadcrumbPanel', { classNames: 'panel', originalUI: ui })
   // TODO: when adding full-screen and light theme
   // const uiButtonsPanel = header.addContent(undefined, { classNames: 'panel' })
 
-  partyKeyPanel.addContent(InteractiveKey, {
+  partyKeyPanel.addContent('InteractiveKey', {
     name: 'user',
     targetType: 'party',
     label: 'Your code'
   })
-  partyKeyPanel.addContent(InteractiveKey, {
+  partyKeyPanel.addContent('InteractiveKey', {
     name: 'external',
     targetType: 'party',
     label: 'Module code'
   })
-  partyKeyPanel.addContent(InteractiveKey, {
+  partyKeyPanel.addContent('InteractiveKey', {
     name: 'nodecore',
     targetType: 'party',
     label: 'Node core'
   })
 
-  typeKeyPanel.addContent(InteractiveKey, {
+  typeKeyPanel.addContent('InteractiveKey', {
     name: 'files-streams',
     targetType: 'type',
     label: 'Files/Streams'
   })
-  typeKeyPanel.addContent(InteractiveKey, {
+  typeKeyPanel.addContent('InteractiveKey', {
     name: 'networks',
     targetType: 'type',
     label: 'Networks'
   })
-  typeKeyPanel.addContent(InteractiveKey, {
+  typeKeyPanel.addContent('InteractiveKey', {
     name: 'crypto',
     targetType: 'type',
     label: 'Crypto'
   })
-  typeKeyPanel.addContent(InteractiveKey, {
+  typeKeyPanel.addContent('InteractiveKey', {
     name: 'timing-promises',
     targetType: 'type',
     label: 'Timing/Promises'
   })
-  typeKeyPanel.addContent(InteractiveKey, {
+  typeKeyPanel.addContent('InteractiveKey', {
     name: 'other',
     targetType: 'type',
     label: 'Other'
@@ -71,11 +65,11 @@ function drawOuterUI () {
   const nodeLink = ui.sections.get('node-link')
   nodeLink.addLoadingAnimation()
 
-  const nodeLinkSVG = nodeLink.addContent(SvgContainer, {id: 'node-link-svg', svgBounds: {}})
+  const nodeLinkSVG = nodeLink.addContent('SvgContainer', {id: 'node-link-svg', svgBounds: {}})
   nodeLinkSVG.addBubbles()
   nodeLinkSVG.addLinks()
 
-  nodeLink.addContent(HoverBox, {svg: nodeLinkSVG})
+  nodeLink.addContent('HoverBox', {svg: nodeLinkSVG})
 
   // Sidebar
   const sideBar = ui.sections.get('side-bar')
@@ -92,7 +86,7 @@ function drawOuterUI () {
     htmlContent: staticKeyHtml
   }).addCollapseControl(false, { htmlContent: 'Key <span class="arrow"></span>' })
 
-  const lookup = sideBar.addContent(Lookup, {
+  const lookup = sideBar.addContent('Lookup', {
     classNames: 'side-bar-item',
     defaultText: 'Enter a file or function name'
   })
@@ -113,7 +107,7 @@ function drawOuterUI () {
     collapseEvent: 'main-overlay',
     closeIcon: '×'
   })
-  footer.addContent(Frames, { id: 'frames-panel', classNames: 'side-bar-item' })
+  footer.addContent('Frames', { id: 'frames-panel', classNames: 'side-bar-item' })
 
   // Complete
   ui.initializeElements()


### PR DESCRIPTION
Yet another small PR spun out of the async processes chart work. This one is also a refactor, so there should be no visible UI changes.

This one changes the way `.addContent` works. Previously, you passed in the class constructor of the content class to create, which was hacky, but worked. A problem with that, which now needs fixing, is that it requires `require()`s for each of the html content classes in each file where `.addContent` is used. The PR I'm working on has a HoverBox that contains a LineChart that contains another smaller HoverBox, which would create a circular dependency with is incompatible with browserify.

This changes it so you pass the name of the class constructor to `.addContent` instead of the constructor itself. There is then an object map which requires in all the different constructors, allowing an A in a B in an A without circular references.