### PR TITLE
Fix traversal between chained collapsed nodes

### DIFF
--- a/visualizer/layout/collapsed-layout.js
+++ b/visualizer/layout/collapsed-layout.js
@@ -165,6 +165,7 @@ class CollapsedLayoutNode {
       const node = layoutNode.node
       if (!this.node) {
         this.node = new ArtificialNode({
+          id: this.id,
           nodeType: node.constructor.name
         }, node)
       }


### PR DESCRIPTION
Very small bug fix but it could potentially have side effects so should be properly tested on its own.

Previously, we had a bug where if there is a chain of collapsed nodes, and you traverse from one to another by clicking on shortcutNodes, it can fail with an error like `cannot call method .jumpToNode() on undefined`. This turned out to be due to a mismatch between the id of a collapsedLayoutNode and the id of the data node it contains.

This makes them match. It fixes the bug, passes all tests, and everything I've tried still works fine.