### PR TITLE
better support for custom async_hooks

### DIFF
--- a/analysis/barrier/name-barrier-nodes.js
+++ b/analysis/barrier/name-barrier-nodes.js
@@ -221,7 +221,7 @@ function groupType (node, sysInfo) {
     case 'FSREQWRAP':
       return ['fs']
     default:
-      return []
+      return isCustomType(node.type) ? [node.type] : []
   }
 }
 
@@ -247,5 +247,11 @@ function toName (types) {
   if (types.includes('promise')) return 'promise'
   if (types.includes('random-bytes')) return 'random-bytes'
 
-  return ''
+  const customTypes = types.filter(isCustomType)
+  return customTypes.length ? customTypes[0] : ''
+}
+
+function isCustomType (type) {
+  // currently the user type heuristic is module:type
+  return type.indexOf(':') > -1
 }


### PR DESCRIPTION
If a async_hook has a `:` (ie, module-name:type) in the name we consider it a custom user type and prefer that as a name

Before:

![2018-06-11-115626_1920x1080_scrot](https://user-images.githubusercontent.com/376661/41225223-a75cf0ea-6d6e-11e8-8355-83ba1995184d.png)

After:

![2018-06-11-115606_1920x1080_scrot](https://user-images.githubusercontent.com/376661/41225214-a3d1f272-6d6e-11e8-810e-f0b3d4ed00e7.png)

(see the cluster on the right)