### PR TITLE
Fix typo and pluralisation in chart text

### DIFF
--- a/visualizer/draw/line-chart.js
+++ b/visualizer/draw/line-chart.js
@@ -194,8 +194,8 @@ class LineChart extends HtmlContent {
     const pluralResources = this.ui.dataSet.sourceNodesCount !== 1
 
     return `
-      <strong>${this.ui.dataSet.callbackEventsCount}</strong> call${ pluralCalls ? 's were' : ' was'} made
-      to ${this.ui.dataSet.sourceNodesCount} asynchronous resource${ pluralResources ? 's' : '' }, over
+      <strong>${this.ui.dataSet.callbackEventsCount}</strong> call${pluralCalls ? 's were' : ' was'} made
+      to ${this.ui.dataSet.sourceNodesCount} asynchronous resource${pluralResources ? 's' : ''}, over
       a ${(this.ui.dataSet.wallTime.profileDuration).toFixed(0)} millisecond period.
     `
   }


### PR DESCRIPTION
Spotted an embarrassing typo ("asynchronously") and pluralisation bug ("1 calls were") when testing another PR:

![image](https://user-images.githubusercontent.com/29628323/41466472-562da7a8-709a-11e8-98de-d23cb8ca047c.png)

After:

![image](https://user-images.githubusercontent.com/29628323/41466514-82876758-709a-11e8-8d32-77c1314ea0c1.png)