### PR TITLE
Ensure ancestor stems are created exactly once

### DIFF
--- a/visualizer/layout/layout.js
+++ b/visualizer/layout/layout.js
@@ -138,10 +138,15 @@ class Layout {
   }
 
   processBetweenData (generateConnections = true) {
+    // If re-doing after scale, remove old pre-scale pre-collapse stems
+    if (generateConnections) this.layoutNodes.forEach(layoutNode => { layoutNode.stem = null })
+
     const layoutNodesIterator = this.layoutNodes.values()
     for (let i = 0; i < this.layoutNodes.size; ++i) {
       const layoutNode = layoutNodesIterator.next().value
-      layoutNode.stem = new Stem(this, layoutNode)
+
+      // Missing ancestor stems are created within descendents' new Stem, so stem might already exist
+      if (!layoutNode.stem) layoutNode.stem = new Stem(this, layoutNode)
 
       if (generateConnections && layoutNode.parent) {
         const connection = new Connection(layoutNode.parent, layoutNode, this.scale)

--- a/visualizer/layout/stems.js
+++ b/visualizer/layout/stems.js
@@ -10,10 +10,17 @@ function getNodeAncestorIds (parent) {
 class Stem {
   constructor (layout, layoutNode) {
     this.layout = layout
+
+    // Ancestor stem stats must be calculated before descendent stem stats
+    const parent = layoutNode.parent
+    if (parent && !parent.stem) {
+      parent.stem = new Stem(layout, parent)
+    }
+
     this.ancestors = {
       totalBetween: 0,
       totalDiameter: 0,
-      ids: getNodeAncestorIds(layoutNode.parent)
+      ids: getNodeAncestorIds(parent)
     }
     this.leaves = {
       ids: []


### PR DESCRIPTION
Nasty bug, this one. The only reliable way I can find to replicate it is clicking on the central long-line `nextTick + connection` node in sample 6984, _only if the screen hasn't been resized_ (so the bug won't have been observable if, for example, you open dev tools after opening a sample...), which throws an error and fails to open. It happens if the layoutNodes iterator order has a node before one of its ancestors; which seems to happen in rare cases (the one observed one had a collapsed node as the only mid point between a root node and a shortcut). 

To stop this being an issue and ensure the process is order-agnostic, I've had each new stem check its parent has a stem; since that parent's stem will have checked its parent, and so on, this means the whole ancestor chain is checked.

This also makes it necessary to clear out the old stems before recreating them after applying scale and collapse. Doing so also prevents a few quirks: this could have been behind some of the rare impossible-to-replicate surprising layouts we've seen recently, if a collapsed node accessed an ancestor stem out of sequence, it would get incorrect data without throwing an error.