### PR TITLE
Add a prominent link to Bubbleprof help page, animated if not visited

### DIFF
--- a/visualizer/draw/index.js
+++ b/visualizer/draw/index.js
@@ -20,6 +20,9 @@ function drawOuterUI () {
 
   header.addContent(undefined, {
     classNames: 'help-link-block panel',
+    // Uncomment this and comment out the other line to test that the animation doesn't play when the page is visited
+    // TODO: remove this when https://clinicjs.org is live
+    // htmlContent: '<a class="help-link external-link" href="https://www.bbc.com/news" title="Test link to a visitable page"></a>'
     htmlContent: '<a class="help-link external-link" href="https://clinicjs.org/bubbleprof/walkthrough" title="External link to NearForm’s BubbleProf walkthrough"></a>'
   })
 

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -266,28 +266,75 @@ main {
 #header .help-link-block {
   position: absolute;
   right: 0;
-  padding: 2px;
+  padding: 2px 0;
+  margin-top: 3px;
   background: var(--main-bg-translucent)
+  border-radius: 6px;
 }
 
 #header .help-link-block .help-link {
+  padding: 1px 3px;
   display: block;
-  padding: 2px 0;
   font-weight: bold;
-  color: var(--cyan);
   text-decoration: none;
+  outline: 4px solid var(--banner-bg-color);
 }
 
 #header .help-link-block .help-link:before {
   content: 'How to use this';
 }
 
+/* unvisited link only */
 #header .help-link-block .help-link:link {
-  border-bottom: 2px solid var(--cyan-highlight);
+  animation-name: pulseLink;
+  color: var(--pure-white);
+  background-color: var(--banner-bg-color);
 }
 
+#header .help-link-block .help-link:link:after {
+  animation-name: pulseIcon;
+  color: var(--pure-white);
+  border-left-color: var(--pure-white);
+  border-bottom-color: var(--pure-white);
+}
+
+#header .help-link-block .help-link:link,
+#header .help-link-block .help-link:link:after {
+  animation-direction: alternate;
+  animation-duration: 0.8s;
+  animation-iteration-count: 8;
+  animation-timing-function: ease-in-out;
+}
+
+
 #header .help-link-block .help-link:visited {
-  border-bottom: 2px solid var(--nearform-grey);
+  background-color: var(--main-bg-color) !important;
+  outline-color: var(--main-bg-color) !important;
+  color: var(--cyan) !important;
+
+  /* :visited can't apply animation-name: none; */
+}
+
+#header .help-link-block .help-link:visited:after {
+    color: var(--cyan);
+    border-left-color: var(--cyan);
+    border-bottom-color: var(--cyan);
+  /* :visited can't apply animation-name: none; */
+}
+
+@keyframes pulseLink {
+  100% {
+    background-color: var(--main-bg-color);
+    color: var(--cyan);
+    outline-color: var(--main-bg-color);
+  }
+}
+@keyframes pulseIcon {
+  100% {
+    color: var(--cyan);
+    border-left-color: var(--cyan);
+    border-bottom-color: var(--cyan);
+  }
 }
 
 .type-icon,
@@ -1346,21 +1393,20 @@ body:not(.initialized):after {
     width: 7px;
     margin-right: 3px;
   }
-
-  #header .help-link-block {
-    top: 2px;
-  }
-  #header .help-link-block .help-link:before {
-    content: 'Help';
-  }
-  #header .highlight-bar .panel:last-child {
-    margin-right: 52px;
-  }
 }
 
 @media only screen and (max-width: 635px){
   body {
     --header-height: 75px;
+  }
+  #header .help-link-block {
+    top: 1px;
+  }
+  #header .help-link-block .help-link:before {
+    content: 'Help';
+  }
+  #header .highlight-bar .panel:last-child {
+    margin-right: 75px;
   }
 }
 


### PR DESCRIPTION
This adds a link to the soon-to-launch Bubbleprof help page. If that page is not `:visited` in the user's browser, the link animates with a noticable-but-not-too-annoying glow effect 4 times, then ends as a bright white link on a raised grey background:

![image](https://user-images.githubusercontent.com/29628323/41724357-44202cdc-7565-11e8-9b34-9c697490f3d2.png)

If the user has visited the external help page on this machine before, the link displays as a less prominent cyan more in keeping with the rest of the UI, and the animation doesn't play:

![image](https://user-images.githubusercontent.com/29628323/41724449-797c9c62-7565-11e8-9526-29688bba9eda.png)

Obviously it's tricky to compare `:visited` and not visited when the site isn't live. There's a line near the top of `visualizer/draw/index.js` you can comment and comment out that switches the link from the clinic site to BBC news for convenient testing.

On narrower windows, the link text shortens and it moves up so as to not collide with the breadcrumbs. 

Not visited:

![image](https://user-images.githubusercontent.com/29628323/41724629-d83550b4-7565-11e8-9261-a8ec45daf2f8.png)


Visited:

![image](https://user-images.githubusercontent.com/29628323/41724609-c93f1360-7565-11e8-8653-91c87bcb58fb.png)

Also, for consistency, this PR adds 'open in new tab' icon and functionality to the other non-logo external links:

![image](https://user-images.githubusercontent.com/29628323/41724703-0b4caa7e-7566-11e8-931a-bf75e1c10d6e.png)
