### PR TITLE
can anon win paths on unix and vice versa

### DIFF
--- a/analysis/stack-trace/frames.js
+++ b/analysis/stack-trace/frames.js
@@ -76,7 +76,8 @@ class Frame {
 
   anonymise (systemInfo) {
     if (this.isNodecore(systemInfo) || !this.fileName || this.fileName[0] === '.') return
-    const rel = path.relative(systemInfo.mainDirectory, this.fileName)
+    const { relative } = (systemInfo.pathSeperator === '/' ? path.posix : path.win32)
+    const rel = relative(systemInfo.mainDirectory, this.fileName)
     if (!rel || rel[0] === '.') this.fileName = rel
     else this.fileName = '.' + systemInfo.pathSeperator + rel
   }


### PR DESCRIPTION
Fixes an issue where when trying to anonymise windows stacks on unix and vice versa it would fail