### PR TITLE
Drop old logic

### DIFF
--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -35,7 +35,6 @@ class BubbleprofUI extends EventEmitter {
     this.selectedDataNode = null
     this.name = this.parentUI && this.parentUI.selectedDataNode.name
     this.name = this.name || 'Main view'
-    this.name = this.name.split(' ').filter(str => !str.includes('/') && !str.includes(':')).join(' ')
 
     // Main divisions of the page
     this.sections = new Map()


### PR DESCRIPTION
Fixes a bug in breadcrumbs where `mongojs:cursor` would get converted into `Main Menu`
The old issue this code was addressing has been solved better by new aggregate nodes naming logic