### PR TITLE
Rename 'line chart' to 'area chart' everywhere

### DIFF
--- a/visualizer/draw/area-chart.js
+++ b/visualizer/draw/area-chart.js
@@ -3,7 +3,7 @@
 const d3 = require('./d3-subset.js')
 const HtmlContent = require('./html-content.js')
 
-class LineChart extends HtmlContent {
+class AreaChart extends HtmlContent {
   constructor (d3Container, contentProperties = {}) {
     super(d3Container, Object.assign({
       static: true,
@@ -45,21 +45,22 @@ class LineChart extends HtmlContent {
     super.initializeElements()
     const margins = this.contentProperties.margins
 
-    this.d3Element.classed('line-chart', true)
+    this.d3Element.classed('area-chart', true)
 
     this.d3ChartWrapper = this.d3ContentWrapper.append('div')
-      .classed('line-chart', true)
+      .classed('area-chart', true)
 
-    this.d3LineChartSVG = this.d3ChartWrapper.append('svg')
-      .classed('line-chart-svg', true)
+    this.d3AreaChartSVG = this.d3ChartWrapper.append('svg')
+      .classed('area-chart-svg', true)
 
-    this.d3LineChartGroup = this.d3LineChartSVG.append('g')
+    this.d3ChartOuter = this.d3AreaChartSVG.append('g')
+      .classed('chart-outer', true)
       .attr('transform', `translate(${margins.left}, ${margins.top})`)
 
-    this.d3LinesGroup = this.d3LineChartGroup.append('g')
-      .classed('lines-group', true)
+    this.d3ChartInner = this.d3ChartOuter.append('g')
+      .classed('chart-inner', true)
 
-    this.d3XAxisGroup = this.d3LineChartGroup.append('g')
+    this.d3XAxisGroup = this.d3ChartOuter.append('g')
       .classed('axis-group', true)
       .classed('x-axis', true)
 
@@ -127,17 +128,17 @@ class LineChart extends HtmlContent {
     }
   }
   initializeFromData () {
-    if (this.d3Lines) {
-      this.d3Lines.data(this.stackedData)
+    if (this.d3AreaPaths) {
+      this.d3AreaPaths.data(this.stackedData)
       return
     }
-    this.d3Lines = this.d3LinesGroup.selectAll('.area-line')
+    this.d3AreaPaths = this.d3ChartInner.selectAll('.area-path')
       .data(this.stackedData)
       .enter()
       .append('path')
       .attr('class', d => `type-${this.getAggregateNode(d.key).typeCategory}`)
-      .classed('area-line-even', d => !(d.index % 2))
-      .classed('area-line', true)
+      .classed('area-path-even', d => !(d.index % 2))
+      .classed('area-path', true)
       .on('mouseover', (d) => {
         if (this.parentContent.constructor.name === 'HoverBox') return
         const aggregateNode = this.getAggregateNode(d.key)
@@ -162,7 +163,7 @@ class LineChart extends HtmlContent {
       })
 
     // Same behaviour on mouse movements off coloured area as on
-    this.d3LineChartSVG.on('mousemove', () => {
+    this.d3AreaChartSVG.on('mousemove', () => {
       this.showSlice(d3.event)
     })
 
@@ -197,7 +198,7 @@ class LineChart extends HtmlContent {
     // Note: d3.event is a live binding which fails if d3 is not bundled in a recommended way.
     // See, for example, https://github.com/d3/d3-sankey/issues/30#issuecomment-307869620
 
-    const width = this.d3LineChartSVG.node().getBoundingClientRect().width
+    const width = this.d3AreaChartSVG.node().getBoundingClientRect().width
     const margins = this.contentProperties.margins
 
     // Show nothing if mouse movement is within chart margins
@@ -237,7 +238,7 @@ class LineChart extends HtmlContent {
       const {
         width,
         height
-      } = this.d3LineChartSVG.node().getBoundingClientRect()
+      } = this.d3AreaChartSVG.node().getBoundingClientRect()
       const margins = this.contentProperties.margins
 
       const usableHeight = height - margins.bottom - margins.top
@@ -249,26 +250,26 @@ class LineChart extends HtmlContent {
         this.d3LeadInText.html(this.getLeadInText())
         */
 
-        this.d3LineChartSVG.classed('filter-applied', true)
-        this.d3Lines.classed('filtered', d => {
+        this.d3AreaChartSVG.classed('filter-applied', true)
+        this.d3AreaPaths.classed('filtered', d => {
           if (!this.layoutNode) return false
           return !this.layoutNodeHasAggregateId(d.key)
         })
         if (this.ui.highlightedDataNode) {
-          this.d3Lines.classed('not-emphasised', d => {
+          this.d3AreaPaths.classed('not-emphasised', d => {
             const aggregateNode = this.getAggregateNode(d.key)
             return (aggregateNode !== this.ui.highlightedDataNode)
           })
         }
       } else {
-        this.d3LineChartSVG.classed('filter-applied', false)
-        this.d3Lines.classed('filtered', false)
+        this.d3AreaChartSVG.classed('filter-applied', false)
+        this.d3AreaPaths.classed('filtered', false)
       }
 
       this.xScale.range([0, usableWidth])
       this.yScale.range([usableHeight, 0])
 
-      this.d3Lines.attr('d', this.areaMaker)
+      this.d3AreaPaths.attr('d', this.areaMaker)
 
       const xAxis = d3.axisBottom()
         .ticks(width < 160 ? 5 : 9) // Show fewer ticks if less space is available
@@ -310,4 +311,4 @@ class LineChart extends HtmlContent {
   }
 }
 
-module.exports = LineChart
+module.exports = AreaChart

--- a/visualizer/draw/hover-box.js
+++ b/visualizer/draw/hover-box.js
@@ -44,7 +44,7 @@ class HoverBox extends HtmlContent {
     this.d3ClickMessage = this.d3TitleBlock.append('a')
       .classed('click-message', true)
 
-    this.asyncOperationsChart = this.addContent('LineChart', {
+    this.asyncOperationsChart = this.addContent('AreaChart', {
       classNames: 'block time-block',
       static: false
     })

--- a/visualizer/draw/html-content-types.js
+++ b/visualizer/draw/html-content-types.js
@@ -11,7 +11,7 @@ module.exports = {
   Frames: require('./frames.js'),
   HoverBox: require('./hover-box.js'),
   InteractiveKey: require('./interactive-key.js'),
-  LineChart: require('./line-chart.js'),
+  AreaChart: require('./area-chart.js'),
   Lookup: require('./lookup.js'),
   SvgContainer: require('./svg-container.js')
 }

--- a/visualizer/draw/index.js
+++ b/visualizer/draw/index.js
@@ -172,7 +172,7 @@ function drawOuterUI () {
   lookup.addCollapseControl(true, { htmlContent: 'Search <span class="arrow"></span>' })
   lookup.addLoadingAnimation({ hidden: true })
 
-  const callbacksOverTime = sideBar.addContent('LineChart', {
+  const callbacksOverTime = sideBar.addContent('AreaChart', {
     classNames: 'side-bar-item'
   })
   callbacksOverTime.addCollapseControl(false, { htmlContent: 'Async operations <span class="arrow"></span>' })

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -886,9 +886,9 @@ body[data-highlight-party='nodecore'] #node-link svg:not(:hover) .party-root {
   stroke-width: 4px !important;
 }
 
-/* Line / Area chart */
+/* Area chart */
 
-.line-chart-svg {
+.area-chart-svg {
   width: 100%;
   height: 70px;
   display: block;
@@ -897,46 +897,46 @@ body[data-highlight-party='nodecore'] #node-link svg:not(:hover) .party-root {
   z-index: 2;
 }
 
-.line-chart {
+.area-chart {
   position: relative;
   font-size: var(--main-text-size);
 }
 
-.line-chart .slice-highlight {
+.area-chart .slice-highlight {
   background: var(--cyan-bright);
   opacity: 0.2;
   position: absolute;
   z-index: 1;
 }
 
-.line-chart .hover-box {
+.area-chart .hover-box {
   width: 135px;
   color: var(--grey-highlight);
 }
 
-.line-chart .hover-box .title-block {
+.area-chart .hover-box .title-block {
   padding: 12px 8px;
 }
 
-.line-chart .hover-box strong {
+.area-chart .hover-box strong {
   color: var(--pure-white);
 }
 
-.line-chart .hover-box .vertical-arrow {
+.area-chart .hover-box .vertical-arrow {
   margin-left: 9px;
 }
 
-#node-link .line-chart .hover-box > .vertical-arrow {
+#node-link .area-chart .hover-box > .vertical-arrow {
   border-top-color: var(--main-bg-translucent);
 }
 
-#node-link .line-chart .hover-box {
+#node-link .area-chart .hover-box {
   background: var(--main-bg-translucent);
   margin-top: -55px;
   margin-left: 6px;
 }
 
-#side-bar .line-chart .hover-box {
+#side-bar .area-chart .hover-box {
   margin-top: -32px;
 }
 
@@ -1193,42 +1193,42 @@ body[data-highlight-party='nodecore'] #node-link svg:not(:hover) .party-root {
 
 /* In area chart specifically, apply to fill instead of stroke */
 
-svg.line-chart-svg .area-line {
+svg.area-chart-svg .area-path {
   stroke: none;
   opacity: 0.8;
   cursor: pointer;
 }
-svg.line-chart-svg .area-line-even {
+svg.area-chart-svg .area-path-even {
   opacity: 0.6;
 }
-svg.line-chart-svg .area-line:hover {
+svg.area-chart-svg .area-path:hover {
   mix-blend-mode: screen;
   opacity: 1;
 }
-svg.line-chart-svg .area-line.type-files-streams {
+svg.area-chart-svg .area-path.type-files-streams {
   fill: var(--type-colour-1);
 }
-svg.line-chart-svg .area-line.type-networks {
+svg.area-chart-svg .area-path.type-networks {
   fill: var(--type-colour-2);
 }
-svg.line-chart-svg .area-line.type-crypto {
+svg.area-chart-svg .area-path.type-crypto {
   fill: var(--type-colour-3);
 }
-svg.line-chart-svg .area-line.type-timing-promises {
+svg.area-chart-svg .area-path.type-timing-promises {
   fill: var(--type-colour-4);
 }
-svg.line-chart-svg .area-line.type-other {
+svg.area-chart-svg .area-path.type-other {
   fill: var(--type-colour-5);
 }
-svg.line-chart-svg.filter-applied .area-line {
+svg.area-chart-svg.filter-applied .area-path {
   animation-name: fade-in;
   animation-duration: 0.4s;
   animation-fill-mode: forwards;
 }
-svg.line-chart-svg.filter-applied .area-line.not-emphasised {
+svg.area-chart-svg.filter-applied .area-path.not-emphasised {
   animation-name: half-fade-out;
 }
-svg.line-chart-svg.filter-applied .area-line.filtered {
+svg.area-chart-svg.filter-applied .area-path.filtered {
   animation-name: mostly-fade-out;
   mix-blend-mode: luminosity;
 }
@@ -1249,24 +1249,24 @@ svg.line-chart-svg.filter-applied .area-line.filtered {
   }
 }
 
-.hover-box .line-chart {
+.hover-box .area-chart {
   background: var(--pure-black);
   opacity: 1;
 }
 
-.line-chart .x-axis .tick text {
+.area-chart .x-axis .tick text {
   fill: var(--nearform-grey);
 }
 
-.line-chart .x-axis .tick line {
+.area-chart .x-axis .tick line {
   stroke: var(--nearform-grey);
 }
 
-.hover-box .line-chart .x-axis .tick line {
+.hover-box .area-chart .x-axis .tick line {
   stroke: var(--main-bg-color);
 }
 
-.line-chart .x-axis .domain {
+.area-chart .x-axis .domain {
   display: none;
 }
 


### PR DESCRIPTION
This is just a renaming PR, doesn't (shouldn't) change any functionality.

The chart of active async operations over time is an area chart but it's sometimes referred to as a line chart in the code, and the references to lines could be mistaken for references to the connecting lines in the main diagram. 

So, to avoid ambiguity, I've renamed it as "area chart" that is made up of "area paths". 