### PR TITLE
Style back button like an undo button

### DIFF
--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -753,15 +753,19 @@ svg.bubbleprof.complete-fade-out {
   width: 40px;
   height: 40px;
   background: var(--pure-black);
-  background-image: var(--down-cyan-chevron-arrow);
-  background-size: cover;
-  transform: rotate(270deg);
   z-index: 20;
   position: absolute;
-  padding: 2px 11px;
+  padding: 2px 10px;
   line-height: 32px;
-  font-size: 28px;
   cursor: pointer;
+  color: var(--cyan);
+}
+
+#node-link .back-btn:before {
+  content: '⤾';
+  display: block;
+  font-size: 21px;
+  font-weight: bold;
 }
 
 #node-link .back-btn.hidden {
@@ -1329,6 +1333,9 @@ body:not(.initialized):after {
   }
   #header .hover-box.use-vertical-arrow .vertical-arrow {
     border-width: 6px;
+  }
+  #node-link .back-btn {
+    left: 8px;
   }
 }
 


### PR DESCRIPTION
As discussed here: https://github.com/nearform/node-clinic-bubbleprof/issues/209

**Before:** The back-arrow-style back button can look like it jumps up one step in the breadcrumbs (in depth), and it can be confusing that the button persists after clearing all sublayouts with the X button - as we are as far 'back' as possible in terms of depth (but not in terms of history). 

However, keeping the back button on using the X button is a useful feature, allowing that action to be undone and allowing the user to pop back to the top layout then go straight back to wherever they were.

![image](https://user-images.githubusercontent.com/29628323/42812380-63365448-89b5-11e8-886f-b1ee81641a3d.png)

**After:** The back button is styled like an undo button, making it clearer that it takes you back in action history, not depth.

![image](https://user-images.githubusercontent.com/29628323/42812364-52a8b198-89b5-11e8-938d-4917fa4c1ef6.png)
