### PR TITLE
do not track on-port detection

### DIFF
--- a/injects/detect-port.js
+++ b/injects/detect-port.js
@@ -4,6 +4,8 @@ const net = require('net')
 const logger = require('./logger')
 
 onlisten(function (addr) {
+  // we do async activity below and we do not want that to pollute the
+  // analysis. we use the skipThis flag to opt out of collecting stats here.
   logger.skipThis = true
   this.destroy()
   const port = Buffer.from(addr.port + '')

--- a/injects/logger.js
+++ b/injects/logger.js
@@ -25,7 +25,7 @@ const out = encoder.pipe(
   })
 )
 
-// log stack traces
+// log stack traces, export a flag to opt out of logging for internals
 exports.skipThis = false
 const skipAsyncIds = new Set()
 const hook = asyncHooks.createHook({


### PR DESCRIPTION
fixes an issue where the `--on-port` detection would show up in the viz

## Before

![2018-07-17-140231_1920x1080_scrot](https://user-images.githubusercontent.com/376661/42816149-21315074-89ca-11e8-9cc9-3934429914c1.png)

## After

![2018-07-17-140237_1920x1080_scrot](https://user-images.githubusercontent.com/376661/42816162-329e9bfa-89ca-11e8-975d-270ee460f85e.png)
