### PR TITLE
Explicitly hide back button until there is history

### DIFF
--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -53,11 +53,15 @@ class BubbleprofUI extends EventEmitter {
 
     if (this.originalUI === this) {
       const nodeLinkSection = this.getNodeLinkSection()
-      this.backBtn = nodeLinkSection.addContent(undefined, { classNames: 'back-btn' })
+      this.backBtn = nodeLinkSection.addContent(undefined, {
+        hidden: true,
+        classNames: 'back-btn'
+      })
       history.push(this)
       this.on('navigation', ({ to }) => {
         history.push(to)
-        this.backBtn.d3Element.classed('hidden', history.length < 2)
+        this.backBtn.isHidden = history.length < 2
+        this.backBtn.draw()
       })
     }
   }


### PR DESCRIPTION
Tiny PR fixing an unspotted 'bug-waiting-to-happen' issue that became a bug in https://github.com/nearform/node-clinic-bubbleprof/pull/213

Previously, it seems like the back button was invisible at start up only because its parent's draw() wasn't being called in the initial draw. A commit in that above PR ensured every htmlContent has its draw() called on startup - which had the unintended side effect of causing the back button to appear on initial page load.

This explicitly sets the hidden state at first, and also updates the content object's state to make sure we don't get any redraw issues.