### PR TITLE
Support browsers that lack position: sticky (like Safari)

### DIFF
--- a/visualizer/draw/index.js
+++ b/visualizer/draw/index.js
@@ -4,8 +4,19 @@ const BubbleprofUI = require('./bubbleprof-ui.js')
 const staticKeyHtml = require('./static-key.js')
 const d3 = require('./d3-subset.js')
 
+const d3Html = d3.select('html')
+
+function addClassIfValueUnsupported (cssProperty, cssValue, d3TestElement) {
+  d3TestElement.style(cssProperty, cssValue)
+  d3Html.classed(`no-${cssProperty}-${cssValue}`, d3TestElement.style(cssProperty) !== cssValue)
+}
+
 function drawOuterUI () {
   // Initial DOM drawing that is independent of data
+
+  const d3TestDiv = d3Html.append('div')
+  addClassIfValueUnsupported('position', 'sticky', d3TestDiv)
+  d3TestDiv.remove()
 
   const sections = ['header', 'node-link', 'side-bar', 'footer']
   const ui = new BubbleprofUI(sections)
@@ -31,7 +42,6 @@ function drawOuterUI () {
     eventHandler: {
       name: 'click',
       func: () => {
-        const d3Html = d3.select('html')
         // Toggle light theme
         d3Html.classed('light-theme', !d3Html.classed('light-theme'))
       }

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -207,6 +207,9 @@ main {
   z-index: 11;
   background: var(--main-bg-color);
 }
+.no-position-sticky #header {
+  position: relative;
+}
 
 #header .header-bar {
   display: block;
@@ -654,6 +657,10 @@ body[data-highlight-type='other'] #header .interactive-key.type-other .type-icon
   cursor: pointer;
   color: var(--cyan-highlight);
 }
+.no-position-sticky #side-bar .close,
+.no-position-sticky #footer .close {
+  position: relative;
+}
 
 /* View modes: 'maximised', 'fit', 'scroll'; */
 
@@ -662,6 +669,10 @@ body[data-view-mode='fit'] #node-link {
   top: var(--header-height);
   max-height: calc(100vh - var(--banner-height) - var(--header-height));
   min-height: calc(100vh - var(--banner-height) - var(--header-height));
+}
+.no-position-sticky body[data-view-mode='fit'] #node-link {
+  position: relative;
+  top: 0;
 }
 
 /* Node-link diagram and container */


### PR DESCRIPTION
CLOSED - SUPERSEDED BY https://github.com/nearform/node-clinic-bubbleprof/pull/223

------

We have three browser issues in Safari listed here - https://github.com/nearform/node-clinic-bubbleprof/issues/218 . Turns out all three are the result of Safari not supporting `position: sticky;`.

So this adds a simple check if that value is supported and a `no-position-sticky` class if it isn't, in a way which can be generalised for any such CSS property value when we find similar problems.

Before (in Safari, version 11.1.2, for Mac):

![image](https://user-images.githubusercontent.com/29628323/43066114-ad9f8f86-8e5b-11e8-9bc9-7e9984a8196c.png)

After:

![image](https://user-images.githubusercontent.com/29628323/43066004-6bd57aac-8e5b-11e8-9a60-1c0d6ef84510.png)
