### PR TITLE
Support browsers that lack position: sticky (like Safari)

### DIFF
--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -326,6 +326,7 @@ main {
 
 #header .hover-box .block {
   background: var(--translucent-reverse);
+  cursor: default;
 }
 
 #header .hover-box.hidden {
@@ -1034,7 +1035,6 @@ body[data-highlight-type='other'] #node-link svg:not(:hover) .type-other {
 }
 
 .hover-box .title-block {
-  cursor: pointer;
   position: relative;
 }
 
@@ -1133,6 +1133,10 @@ body[data-highlight-type='other'] #node-link svg:not(:hover) .type-other {
   border-bottom: none;
   bottom: 0;
   margin-bottom: -9px;
+}
+
+#node-link .hover-box .title-block {
+  cursor: pointer;
 }
 
 /* Lookup box for text-based searches */


### PR DESCRIPTION
We have three browser issues in Safari listed here - https://github.com/nearform/node-clinic-bubbleprof/issues/218 . Turns out all three are the result of Safari not supporting `position: sticky;`.

So this adds a simple check if that value is supported and a `no-position-sticky` class if it isn't, in a way which can be generalised for any such CSS property value when we find similar problems.

Before (in Safari, version 11.1.2, for Mac):

![image](https://user-images.githubusercontent.com/29628323/43066114-ad9f8f86-8e5b-11e8-9bc9-7e9984a8196c.png)

After:

![image](https://user-images.githubusercontent.com/29628323/43066004-6bd57aac-8e5b-11e8-9a60-1c0d6ef84510.png)

(rewrite and reposting of https://github.com/nearform/node-clinic-bubbleprof/pull/221 ) 