### PR TITLE
Run svgElement.draw() when all its animations finish

### DIFF
--- a/visualizer/draw/svg-node-diagram.js
+++ b/visualizer/draw/svg-node-diagram.js
@@ -90,8 +90,6 @@ class SvgNodeDiagram {
     Promise.all(svgNodeAnimations).then(() => {
       this.ui.isAnimating = false
       if (onComplete) onComplete()
-    }, (err) => {
-      throw err
     })
   }
 


### PR DESCRIPTION
This is part one of two for fixing https://github.com/nearform/node-clinic-bubbleprof/issues/224

It fixes the most important part of that bug - it means that if that bug happens, after animations have completed the diagram shows correctly. There is still the problem that in the cases where that bug happens, the ratio of colours within a circle can appear wrong _during_ the animation, but this is only apparent in a few rare cases and only for less than a second.

It's visible in sample 15896.clinic-bubbleprof.html#lclump:C19,C20,C21,C22,C23,C24|m
Trying to upload a sample currently gives error `SyntaxError: Unexpected token < in JSON at position 5` using latest `@nearform/clinic` from npm.

Before: 

![image](https://user-images.githubusercontent.com/29628323/43088512-3959b34c-8e9a-11e8-9809-a9af63060e1c.png)

After:

![image](https://user-images.githubusercontent.com/29628323/43088523-42128658-8e9a-11e8-9fb7-f237f1686601.png)

Another bug is visible in that sample - the grey background circle is visible while the animation takes place. That bug was already fixed in (still pending) PR https://github.com/nearform/node-clinic-bubbleprof/pull/222 