### PR TITLE
Break long words exceeding hover box title width

### DIFF
--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -1062,6 +1062,7 @@ body[data-highlight-type='other'] #node-link svg:not(:hover) .type-other {
   font-size: 13pt;
   color: var(--max-contrast);
   font-weight: bold;
+  word-break: break-all;
 }
 
 .hover-box .click-message {


### PR DESCRIPTION
Pretty self-explanatory.

Before:

![image](https://user-images.githubusercontent.com/29628323/43134938-9e74f4de-8f3b-11e8-8e85-7f8dadb690cc.png)

After:

![image](https://user-images.githubusercontent.com/29628323/43134906-7f019f8a-8f3b-11e8-9333-592591164aef.png)
