### PR TITLE
Share DataSet's debugMode setting with Layout

### DIFF
--- a/test/visualizer-layout-node-allocation.test.js
+++ b/test/visualizer-layout-node-allocation.test.js
@@ -8,13 +8,17 @@ const LineCoordinates = require('../visualizer/layout/line-coordinates.js')
 
 const { mockTopology } = require('./visualizer-util/fake-topology.js')
 
-const settings = {
+const dataSettings = {
+  debugMode: true
+}
+
+const settings = Object.assign({
   svgWidth: 1000,
   svgHeight: 1000,
   labelMinimumSpace: 0,
   lineWidth: 0,
   svgDistanceFromEdge: 30
-}
+}, dataSettings)
 
 test('Visualizer layout - node allocation - all assigned leaf units are proportional to parent and add up to 1', function (t) {
   const topology = [
@@ -23,7 +27,7 @@ test('Visualizer layout - node allocation - all assigned leaf units are proporti
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -60,7 +64,7 @@ test('Visualizer layout - node allocation - three-sided space segments depend on
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -87,7 +91,7 @@ test('Visualizer layout - node allocation - blocks do not overlap or exceed allo
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -122,7 +126,7 @@ test('Visualizer layout - node allocation - xy positions of leaves are allocated
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -151,7 +155,7 @@ test('Visualizer layout - node allocation - xy positions of nodes are allocated 
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -227,7 +231,7 @@ test('Visualizer layout - node allocation - can handle subsets', function (t) {
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   const subset = [6, 7, 8].map(nodeId => dataSet.clusterNodes.get(nodeId))
   const layout = new Layout({ dataNodes: subset }, settings)
@@ -283,7 +287,7 @@ test('Visualizer layout - node allocation - can handle collapsets', function (t)
     ['1.3.7.8.9', 900 - 4],
     ['1.3.7.10.11', 401 - 4]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   dataSet.clusterNodes.get(10).stats.async.between = 100 // make 10 long
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
@@ -344,7 +348,7 @@ test('Visualizer layout - node allocation - can handle collapsets with clumpy le
     ['1.3.7.8.9', 900 - 4],
     ['1.3.7.10.11', 401 - 4]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)

--- a/test/visualizer-layout-positioning.test.js
+++ b/test/visualizer-layout-positioning.test.js
@@ -12,6 +12,8 @@ const {
   topologyToSortedIds
 } = require('./visualizer-util/fake-topology.js')
 
+const settings = { debugMode: true }
+
 test('Visualizer layout - positioning - mock topology', function (t) {
   const topology = [
     ['1.2.8', 100],
@@ -20,7 +22,7 @@ test('Visualizer layout - positioning - mock topology', function (t) {
     ['1.2.3.4', 150],
     ['1.9', 50]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(settings, mockTopology(topology))
   t.ok(dataSet)
 
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
@@ -59,7 +61,7 @@ test('Visualizer layout - positioning - pyramid - simple', function (t) {
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(settings, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
 
   const positioning = layout.positioning
@@ -84,7 +86,7 @@ test('Visualizer layout - positioning - pyramid - gaps', function (t) {
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(settings, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
 
   const positioning = layout.positioning
@@ -115,7 +117,7 @@ test('Visualizer layout - positioning - pyramid - clumping tiny together with lo
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(settings, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
 
   const positioning = layout.positioning
@@ -159,7 +161,7 @@ test('Visualizer layout - positioning - pyramid - example in docs', function (t)
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(settings, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
 
   const positioning = layout.positioning
@@ -183,7 +185,7 @@ test('Visualizer layout - positioning - debugInspect', function (t) {
     ['1.8', 100 - 1]
   ]
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(settings, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0, svgDistanceFromEdge: 0 })
 
   const positioning = layout.positioning
@@ -214,10 +216,10 @@ test('Visualizer layout - positioning - pyramid - can handle subsets', function 
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(settings, mockTopology(topology))
   const subset = [...dataSet.clusterNodes.values()].filter(node => node.id !== 1 && node.id !== 2)
-  const layout = new Layout({ dataNodes: subset })
-  layout.generate()
+  const layout = new Layout({ dataNodes: subset }, settings)
+  layout.generate(settings)
 
   const positioning = layout.positioning
   positioning.formClumpPyramid()
@@ -243,8 +245,8 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets', functi
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
-  const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] })
+  const dataSet = loadData(settings, mockTopology(topology))
+  const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   layout.processHierarchy({ collapseNodes: true })
   // Arbitrary Map order being issue here
   const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 2, 3, 8].every(c => ('' + key).includes(c)))
@@ -278,8 +280,8 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets with clu
   ]
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
-  const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] })
+  const dataSet = loadData(settings, mockTopology(topology))
+  const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   layout.processHierarchy({ collapseNodes: true })
   // Arbitrary Map order being issue here
   const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 2, 3, 8, 12].every(c => ('' + key).includes(c)))

--- a/test/visualizer-layout-scale.test.js
+++ b/test/visualizer-layout-scale.test.js
@@ -10,7 +10,12 @@ const { mockTopology } = require('./visualizer-util/fake-topology.js')
 
 const svgWidth = 1000
 const svgHeight = 1000
-const settings = {
+
+const dataSettings = {
+  debugMode: true
+}
+
+const settings = Object.assign({
   svgWidth,
   svgHeight,
   labelMinimumSpace: 0,
@@ -18,7 +23,7 @@ const settings = {
   svgDistanceFromEdge: 30,
   allowStretch: true,
   collapseNodes: false
-}
+}, dataSettings)
 
 test('Visualizer layout - scale - calculates prescale based on longest', function (t) {
   const topology = [
@@ -26,7 +31,7 @@ test('Visualizer layout - scale - calculates prescale based on longest', functio
     ['1.5', svgHeight / 2],
     ['1.2.6', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.ok(layout.scale.prescaleFactor < 2.00 && layout.scale.prescaleFactor > 1.99)
@@ -38,7 +43,7 @@ test('Visualizer layout - scale - calculates scalable line length', function (t)
   const topology = [
     ['1.2', svgHeight]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.ok(isNumber(layout.scale.scaleFactor))
@@ -52,7 +57,7 @@ test('Visualizer layout - scale - calculates scalable circle radius based on len
   const topology = [
     ['1.2', svgHeight]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.ok(isNumber(layout.scale.scaleFactor))
@@ -67,7 +72,7 @@ test('Visualizer layout - scale - demagnifies large shortest', function (t) {
     ['1.2', svgWidth],
     ['1.3', svgWidth * 0.9]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'shortest')
@@ -80,7 +85,7 @@ test('Visualizer layout - scale - demagnifies large longest and stretches height
   const topology = [
     ['1.2.3.4.5.6.7', svgHeight * 3]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'longest')
@@ -94,7 +99,7 @@ test('Visualizer layout - scale - folds small layouts', function (t) {
   const topology = [
     ['1.2', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   const nodesCount = 2
@@ -110,7 +115,7 @@ test('Visualizer layout - scale - constrained longest superseeds other weights',
     ['1.6', svgWidth * 1.51],
     ['1.7', svgWidth * 1.5]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
 
@@ -130,7 +135,7 @@ test('Visualizer layout - scale - constrained longest superseeds other weights (
     ['1.6', svgWidth * 0.5],
     ['1.7', svgWidth * 0.5]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
 
@@ -147,7 +152,7 @@ test('Visualizer layout - scale - demagnifies large diameter (width)', function 
   const topology = [
     ['1.2.3.4.5', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.layoutNodes.get(2).stem.raw.ownDiameter = svgWidth
   layout.updateScale()
@@ -161,7 +166,7 @@ test('Visualizer layout - scale - demagnifies large diameter (height)', function
   const topology = [
     ['1.2.3.4.5.6.7', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const inputHeight = (250 + 30 + 30) * (1 / 1.5)
   const layout = generateLayout(dataSet, Object.assign({}, settings, { svgHeight: inputHeight }))
   layout.layoutNodes.get(2).stem.raw.ownDiameter = 500
@@ -178,7 +183,7 @@ test('Visualizer layout - scale - demagnifies large q50', function (t) {
     ['1.2', (svgWidth / 0.71) + 10],
     ['1.4', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'q50 1-1-sqrt(2) triangle')
@@ -194,7 +199,7 @@ test('Visualizer layout - scale - demagnifies large q25', function (t) {
     ['1.4', (svgWidth / 0.8) + 10],
     ['1.5', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'q25 4-3-5 triangle')
@@ -211,7 +216,7 @@ test('Visualizer layout - scale - demagnifies large q75', function (t) {
     ['1.4', 1],
     ['1.6', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'q75 3-4-5 triangle')
@@ -224,7 +229,7 @@ test('Visualizer layout - scale - magnifies tiny longest', function (t) {
   const topology = [
     ['1.2.3.4.5', svgHeight / 2]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'longest')
@@ -245,9 +250,9 @@ test('Visualizer layout - scale - can handle subsets', function (t) {
     ['1.2.3.4.5.18', svgWidth * 0.34]
   ]
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const subset = [...dataSet.clusterNodes.values()].filter(node => node.id !== 1 && node.id !== 2)
-  const layout = new Layout({ dataNodes: subset })
+  const layout = new Layout({ dataNodes: subset }, dataSettings)
   layout.generate()
 
   t.ok(layout.scale.scaleFactor < 0.33 && layout.scale.scaleFactor > 0.32)
@@ -259,7 +264,7 @@ test('Visualizer layout - scale - demagnifies when absolutes exceed available sp
   const topology = [
     ['1.2.3.4.5.6.7.8.9.10.11', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, { svgWidth: 100, svgHeight: 100, svgDistanceFromEdge: 5, labelMinimumSpace: 20, lineWidth: 30, collapseNodes: false })
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'longest')
@@ -276,7 +281,7 @@ test('Visualizer layout - scale - can handle zero-sized nodes', function (t) {
     ['1.4', 1]
   ]
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.layoutNodes.get(1).stem.raw.ownDiameter = 0
   layout.layoutNodes.get(2).stem.lengths.scalable = 0
@@ -294,7 +299,7 @@ test('Visualizer layout - scale - can handle zero-sized views', function (t) {
     ['1.4', 0]
   ]
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.layoutNodes.get(1).stem.raw.ownDiameter = 0
   layout.layoutNodes.get(2).stem.lengths.scalable = 0

--- a/test/visualizer-layout.test.js
+++ b/test/visualizer-layout.test.js
@@ -27,20 +27,24 @@ function toTypeId (layoutNode) {
   return layoutNode.node.constructor.name + '-' + layoutNode.id
 }
 
-const settings = {
+const dataSettings = {
+  debugMode: true
+}
+
+const settings = Object.assign({
   svgWidth: 1000,
   svgHeight: 1000,
   labelMinimumSpace: 0,
   lineWidth: 0,
   svgDistanceFromEdge: 30,
   collapseNodes: true
-}
+}, dataSettings)
 
 test('Visualizer layout - builds sublayout from connection', function (t) {
   const topology = [
     ['1.2.3.4.5', 100]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const initialDataNodes = [...dataSet.clusterNodes.values()]
   const uncollapsedSettings = Object.assign({ collapseNodes: false }, settings)
   const initialLayout = new Layout({ dataNodes: initialDataNodes }, uncollapsedSettings)
@@ -62,7 +66,7 @@ test('Visualizer layout - collapse - collapses vertically (except root and Ps)',
   const topology = [
     ['1.2.3.4.5', 100]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   const layout = new Layout({ dataNodes }, settings)
@@ -86,7 +90,7 @@ test('Visualizer layout - collapse - does not collapse shortcut nodes', function
     ['1.2.4', 1],
     ['1.2.5', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const initialDataNodes = [...dataSet.clusterNodes.values()]
   const initialLayout = new Layout({ dataNodes: initialDataNodes }, settings)
   initialLayout.processHierarchy()
@@ -104,7 +108,7 @@ test('Visualizer layout - collapse - merges shortcuts pointing to the same view'
     ['1.2.3.6.7', 1],
     ['1.2.3.8.9', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const initialDataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(2).stats.async.between = 100 // make 2 long
   dataSet.clusterNodes.get(3).stats.async.between = 100 // make 3 long
@@ -131,7 +135,7 @@ test('Visualizer layout - collapse - collapses vertically with break (except roo
   const topology = [
     ['1.2.3.4.5.6.7.8.9', 100]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   dataSet.clusterNodes.get(5).stats.async.between = 100 // make 5 long
@@ -156,7 +160,7 @@ test('Visualizer layout - collapse - collapses vertically until minimum count th
     ['1.2.3.4.5', 1],
     ['1.2.3.4.6', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1000 // make root long
   const layout = new Layout({ dataNodes }, settings)
@@ -187,7 +191,7 @@ test('Visualizer layout - collapse - collapses horizontally', function (t) {
     ['1.2.5.6', 100],
     ['1.2.7.8', 100]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(2).stats.async.between = 100 // make 2 long
   dataSet.clusterNodes.get(5).stats.async.between = 100 // make 5 long
@@ -217,7 +221,7 @@ test('Visualizer layout - collapse - collapses both horizontally and vertically 
     ['1.2.3.4.5', 100],
     ['1.2.6.7.8', 100]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   const layout = new Layout({ dataNodes }, settings)
@@ -245,7 +249,7 @@ test('Visualizer layout - collapse - vertically collapses subset with missing ro
     ['1.2.3.4.5.6', 100],
     ['1.7.8.9.10', 100]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   dataSet.clusterNodes.get(9).stats.async.within = 100 // make 9 long
   const subset = [2, 3, 4, 5, 6, 7, 8, 9, 10].map(nodeId => dataSet.clusterNodes.get(nodeId))
   const layout = new Layout({ dataNodes: subset }, settings)
@@ -277,7 +281,7 @@ test('Visualizer layout - collapse - collapses subset both vertically and horizo
     ['1.2.3.4.5', 100],
     ['1.2.6.7.8', 100]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   dataSet.clusterNodes.get(7).stats.async.between = 100 // make 7 long
   const subset = [1, 2, 3, 4, 6, 7].map(nodeId => dataSet.clusterNodes.get(nodeId))
@@ -317,7 +321,7 @@ test('Visualizer layout - collapse - complex example', function (t) {
     ['1.3.10.11', 1],
     ['1.3.10.12.13', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   dataSet.clusterNodes.get(2).stats.async.within = 100 // make 2 long

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -85,6 +85,8 @@ class BubbleprofUI extends EventEmitter {
 
   getSettingsForLayout () {
     const settings = {}
+    if (this.dataSet && this.dataSet.settings.debugMode) settings.debugMode = true
+
     switch (this.settings.viewMode) {
       case 'fit':
       case 'maximised':

--- a/visualizer/layout/index.js
+++ b/visualizer/layout/index.js
@@ -3,6 +3,9 @@
 const Layout = require('./layout.js')
 
 function generateLayout (dataSet, settings) {
+  settings = Object.assign({
+    debugMode: dataSet.settings.debugMode
+  }, settings)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
 
   // This can be interrupted in tests etc

--- a/visualizer/layout/layout.js
+++ b/visualizer/layout/layout.js
@@ -18,7 +18,8 @@ class Layout {
       svgWidth: 750,
       svgHeight: 750,
       shortcutLength: 60,
-      allowStretch: true
+      allowStretch: true,
+      debugMode: false
     }
     this.settings = Object.assign(defaultSettings, settings)
     this.initialInput = {

--- a/visualizer/layout/positioning.js
+++ b/visualizer/layout/positioning.js
@@ -19,8 +19,9 @@ class Positioning {
     this.order = clumpPyramid.order
   }
   placeNodes () {
-    this.nodeAllocation = new NodeAllocation(this.layout, this.layoutNodes)
-    this.nodeAllocation.process()
+    const nodeAllocation = new NodeAllocation(this.layout, this.layoutNodes)
+    nodeAllocation.process()
+    if (this.layout.settings.debugMode) this.nodeAllocation = nodeAllocation
   }
   debugInspect () {
     const intoOrder = (leafA, leafB) => this.order.indexOf(leafA.id) - this.order.indexOf(leafB.id)


### PR DESCRIPTION
We have a `debugMode` setting which is applied in many tests and can be turned on during dev work by modifying `visualizer/main.js`, which keeps and exposes some data which would otherwise be discarded. Currently it's applied as a setting to instances of DataSet.

This PR, spun out of some work on collapsedLayoutNode ids, shares this setting with instances of Layout (including sublayouts) created from the same dataSet, so that Layout code can be debugMode-only. 

It also updates some tests which create Layout instances in an artificial way calling `new Layout()` directly, which could cause the settings to become out of sync.

It doesn't change anything in outputs or tests, but allows us to store Layout data in debug mode only and write tests that access data which would otherwise be discarded (for example, in the work this PR was spun out from, I want to write a test that ensures that particular collapsedLayoutNodes are created and then squashed and ejected - which would require storing data that is only needed for tests and debugging). 

(fun fact - we currently run exactly 666 `visualizer-*` tests 🤘)