### PR TITLE
 Simpler collapsed node ids, allowing url-encoding-safe hashes

### DIFF
--- a/test/visualizer-layout-node-allocation.test.js
+++ b/test/visualizer-layout-node-allocation.test.js
@@ -291,8 +291,8 @@ test('Visualizer layout - node allocation - can handle collapsets', function (t)
   layout.processHierarchy({ collapseNodes: true })
 
   const keys = [...layout.layoutNodes.keys()]
-  const clumpId = 'x'
-  t.deepEqual([ 1, 2, 3, 'x', 5, 6, 8, 9, 10, 11 ], keys)
+  const clumpId = 'x1'
+  t.deepEqual([ 1, 2, 3, 'x1', 5, 6, 8, 9, 10, 11 ], keys)
   t.deepEqual([ 4, 7 ], layout.layoutNodes.get(clumpId).collapsedNodes.map(layoutNode => layoutNode.id))
 
   layout.positioning.formClumpPyramid()
@@ -354,10 +354,10 @@ test('Visualizer layout - node allocation - can handle collapsets with clumpy le
   layout.processHierarchy({ collapseNodes: true })
 
   const keys = [...layout.layoutNodes.keys()]
-  const firstClumpId = 'x'
-  t.deepEqual([ 1, 'x3', 5, 6, 'x', 9, 11 ], keys)
-  t.deepEqual([ 8, 10 ], layout.layoutNodes.get('x').collapsedNodes.map(layoutNode => layoutNode.id))
-  t.deepEqual([ 2, 3, 4, 7 ], layout.layoutNodes.get('x3').collapsedNodes.map(layoutNode => layoutNode.id))
+  const firstClumpId = 'x1'
+  t.deepEqual([ 1, 'x4', 5, 6, 'x1', 9, 11 ], keys)
+  t.deepEqual([ 8, 10 ], layout.layoutNodes.get('x1').collapsedNodes.map(layoutNode => layoutNode.id))
+  t.deepEqual([ 2, 3, 4, 7 ], layout.layoutNodes.get('x4').collapsedNodes.map(layoutNode => layoutNode.id))
 
   layout.positioning.formClumpPyramid()
   layout.positioning.placeNodes()

--- a/test/visualizer-layout-node-allocation.test.js
+++ b/test/visualizer-layout-node-allocation.test.js
@@ -8,13 +8,17 @@ const LineCoordinates = require('../visualizer/layout/line-coordinates.js')
 
 const { mockTopology } = require('./visualizer-util/fake-topology.js')
 
-const settings = {
+const dataSettings = {
+  debugMode: true
+}
+
+const settings = Object.assign({
   svgWidth: 1000,
   svgHeight: 1000,
   labelMinimumSpace: 0,
   lineWidth: 0,
   svgDistanceFromEdge: 30
-}
+}, dataSettings)
 
 test('Visualizer layout - node allocation - all assigned leaf units are proportional to parent and add up to 1', function (t) {
   const topology = [
@@ -23,7 +27,7 @@ test('Visualizer layout - node allocation - all assigned leaf units are proporti
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -60,7 +64,7 @@ test('Visualizer layout - node allocation - three-sided space segments depend on
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -87,7 +91,7 @@ test('Visualizer layout - node allocation - blocks do not overlap or exceed allo
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -122,7 +126,7 @@ test('Visualizer layout - node allocation - xy positions of leaves are allocated
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -151,7 +155,7 @@ test('Visualizer layout - node allocation - xy positions of nodes are allocated 
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
@@ -227,7 +231,7 @@ test('Visualizer layout - node allocation - can handle subsets', function (t) {
     ['1.3.6.7', 900 - 3],
     ['1.3.6.8', 500 - 3]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   const subset = [6, 7, 8].map(nodeId => dataSet.clusterNodes.get(nodeId))
   const layout = new Layout({ dataNodes: subset }, settings)
@@ -283,7 +287,7 @@ test('Visualizer layout - node allocation - can handle collapsets', function (t)
     ['1.3.7.8.9', 900 - 4],
     ['1.3.7.10.11', 401 - 4]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   dataSet.clusterNodes.get(10).stats.async.between = 100 // make 10 long
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
@@ -347,7 +351,7 @@ test('Visualizer layout - node allocation - can handle collapsets with clumpy le
     ['1.3.7.8.9', 900 - 4],
     ['1.3.7.10.11', 401 - 4]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   t.ok(dataSet)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)

--- a/test/visualizer-layout-node-allocation.test.js
+++ b/test/visualizer-layout-node-allocation.test.js
@@ -289,9 +289,12 @@ test('Visualizer layout - node allocation - can handle collapsets', function (t)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
   layout.processHierarchy({ collapseNodes: true })
-  // Arbitrary Map order being issue here
-  const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 4, 7].every(c => ('' + key).includes(c)))
-  t.ok(clumpId)
+
+  const keys = [...layout.layoutNodes.keys()]
+  const clumpId = 'x'
+  t.deepEqual([ 1, 2, 3, 'x', 5, 6, 8, 9, 10, 11 ], keys)
+  t.deepEqual([ 4, 7 ], layout.layoutNodes.get(clumpId).collapsedNodes.map(layoutNode => layoutNode.id))
+
   layout.positioning.formClumpPyramid()
   layout.positioning.placeNodes()
 
@@ -349,9 +352,13 @@ test('Visualizer layout - node allocation - can handle collapsets with clumpy le
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   t.ok(layout)
   layout.processHierarchy({ collapseNodes: true })
-  // Arbitrary Map order being issue here
-  const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 2, 3, 4, 7].every(c => ('' + key).includes(c)))
-  t.ok(clumpId)
+
+  const keys = [...layout.layoutNodes.keys()]
+  const firstClumpId = 'x'
+  t.deepEqual([ 1, 'x3', 5, 6, 'x', 9, 11 ], keys)
+  t.deepEqual([ 8, 10 ], layout.layoutNodes.get('x').collapsedNodes.map(layoutNode => layoutNode.id))
+  t.deepEqual([ 2, 3, 4, 7 ], layout.layoutNodes.get('x3').collapsedNodes.map(layoutNode => layoutNode.id))
+
   layout.positioning.formClumpPyramid()
   layout.positioning.placeNodes()
 
@@ -379,18 +386,18 @@ test('Visualizer layout - node allocation - can handle collapsets with clumpy le
   t.equal(positionById[1].x.toFixed(0), (layout.settings.svgWidth / 2).toFixed(0))
   t.equal(positionById[1].y.toFixed(0), (layout.settings.svgDistanceFromEdge + layout.layoutNodes.get(1).stem.scaled.ownDiameter).toFixed(0))
 
-  t.ok(positionById[11].y > positionById[clumpId].y)
-  t.ok(positionById[11].x < positionById[clumpId].x)
+  t.ok(positionById[11].y > positionById[firstClumpId].y)
+  t.ok(positionById[11].x < positionById[firstClumpId].x)
   t.ok(distanceById[11] < scaledStemById[11].ownBetween * 1.01)
   t.ok(distanceById[11] > scaledStemById[11].ownBetween * 0.99)
 
-  t.ok(positionById[9].y > positionById[clumpId].y)
-  t.ok(positionById[9].x < positionById[clumpId].x)
+  t.ok(positionById[9].y > positionById[firstClumpId].y)
+  t.ok(positionById[9].x < positionById[firstClumpId].x)
   t.ok(distanceById[9] < scaledStemById[9].ownBetween * 1.01)
   t.ok(distanceById[9] > scaledStemById[9].ownBetween * 0.99)
 
-  t.ok(positionById[6].y > positionById[clumpId].y)
-  t.ok(positionById[6].x > positionById[clumpId].x)
+  t.ok(positionById[6].y > positionById[firstClumpId].y)
+  t.ok(positionById[6].x > positionById[firstClumpId].x)
   t.ok(distanceById[6] < scaledStemById[6].ownBetween * 1.01)
   t.ok(distanceById[6] > scaledStemById[6].ownBetween * 0.99)
 

--- a/test/visualizer-layout-positioning.test.js
+++ b/test/visualizer-layout-positioning.test.js
@@ -246,9 +246,14 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets', functi
   const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] })
   layout.processHierarchy({ collapseNodes: true })
+
+  const keys = [...layout.layoutNodes.keys()]
+  t.deepEqual([ 1, 'x2', 11, 'x', 5, 7, 9, 10, 12 ], keys)
+  t.deepEqual([ 4, 6 ], layout.layoutNodes.get('x').collapsedNodes.map(layoutNode => layoutNode.id))
+  t.deepEqual([ 2, 3, 8 ], layout.layoutNodes.get('x2').collapsedNodes.map(layoutNode => layoutNode.id))
+
   // Arbitrary Map order being issue here
-  const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 2, 3, 8].every(c => ('' + key).includes(c)))
-  t.ok(clumpId)
+  // const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 2, 3, 8].every(c => ('' + key).includes(c)))
   const positioning = layout.positioning
   positioning.formClumpPyramid()
 
@@ -257,10 +262,10 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets', functi
 
   const expectedClumpedTopology = [
     ['1.12', 50],
-    ['1.clump:C2,C3,C8.clump:C4,C6.5', 400],
-    ['1.clump:C2,C3,C8.clump:C4,C6.7', 250],
-    ['1.clump:C2,C3,C8.9.10', 200],
-    ['1.clump:C2,C3,C8.11', 100]
+    ['1.x2.x.5', 400],
+    ['1.x2.x.7', 250],
+    ['1.x2.9.10', 200],
+    ['1.x2.11', 100]
   ]
   const expectedSortedIds = topologyToSortedIds(expectedClumpedTopology, false)
   t.deepEqual(layout.getSortedLayoutNodes().map(layoutNode => `${layoutNode.id}`), expectedSortedIds)
@@ -281,19 +286,22 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets with clu
   const dataSet = loadData({ debugMode: true }, mockTopology(topology))
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] })
   layout.processHierarchy({ collapseNodes: true })
-  // Arbitrary Map order being issue here
-  const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 2, 3, 8, 12].every(c => ('' + key).includes(c)))
-  t.ok(clumpId)
+
+  const keys = [...layout.layoutNodes.keys()]
+  t.deepEqual([ 1, 'x3', 11, 'x', 5, 7, 9, 10 ], keys)
+  t.deepEqual([ 4, 6 ], layout.layoutNodes.get('x').collapsedNodes.map(layoutNode => layoutNode.id))
+  t.deepEqual([ 2, 12, 3, 8 ], layout.layoutNodes.get('x3').collapsedNodes.map(layoutNode => layoutNode.id))
+
   const positioning = layout.positioning
   positioning.formClumpPyramid()
 
   t.deepEqual(positioning.order, [5, 7, 10, 11])
 
   const expectedClumpedTopology = [
-    ['1.clump:C2,C3,C8,C12.clump:C4,C6.5', 401],
-    ['1.clump:C2,C3,C8,C12.clump:C4,C6.7', 250],
-    ['1.clump:C2,C3,C8,C12.9.10', 200],
-    ['1.clump:C2,C3,C8,C12.11', 100]
+    ['1.x3.x.5', 401],
+    ['1.x3.x.7', 250],
+    ['1.x3.9.10', 200],
+    ['1.x3.11', 100]
   ]
 
   const expectedSortedIds = topologyToSortedIds(expectedClumpedTopology, false)

--- a/test/visualizer-layout-positioning.test.js
+++ b/test/visualizer-layout-positioning.test.js
@@ -12,6 +12,8 @@ const {
   topologyToSortedIds
 } = require('./visualizer-util/fake-topology.js')
 
+const settings = { debugMode: true }
+
 test('Visualizer layout - positioning - mock topology', function (t) {
   const topology = [
     ['1.2.8', 100],
@@ -20,7 +22,7 @@ test('Visualizer layout - positioning - mock topology', function (t) {
     ['1.2.3.4', 150],
     ['1.9', 50]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(settings, mockTopology(topology))
   t.ok(dataSet)
 
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
@@ -59,7 +61,7 @@ test('Visualizer layout - positioning - pyramid - simple', function (t) {
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(settings, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
 
   const positioning = layout.positioning
@@ -84,7 +86,7 @@ test('Visualizer layout - positioning - pyramid - gaps', function (t) {
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(settings, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
 
   const positioning = layout.positioning
@@ -115,7 +117,7 @@ test('Visualizer layout - positioning - pyramid - clumping tiny together with lo
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(settings, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
 
   const positioning = layout.positioning
@@ -159,7 +161,7 @@ test('Visualizer layout - positioning - pyramid - example in docs', function (t)
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(settings, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0 })
 
   const positioning = layout.positioning
@@ -183,7 +185,7 @@ test('Visualizer layout - positioning - debugInspect', function (t) {
     ['1.8', 100 - 1]
   ]
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(settings, mockTopology(topology))
   const layout = generateLayout(dataSet, { labelMinimumSpace: 0, lineWidth: 0, svgDistanceFromEdge: 0 })
 
   const positioning = layout.positioning
@@ -214,10 +216,10 @@ test('Visualizer layout - positioning - pyramid - can handle subsets', function 
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(settings, mockTopology(topology))
   const subset = [...dataSet.clusterNodes.values()].filter(node => node.id !== 1 && node.id !== 2)
-  const layout = new Layout({ dataNodes: subset })
-  layout.generate()
+  const layout = new Layout({ dataNodes: subset }, settings)
+  layout.generate(settings)
 
   const positioning = layout.positioning
   positioning.formClumpPyramid()
@@ -243,8 +245,8 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets', functi
   const expectedTopology = Object.assign([], topology)
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
-  const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] })
+  const dataSet = loadData(settings, mockTopology(topology))
+  const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   layout.processHierarchy({ collapseNodes: true })
 
   const keys = [...layout.layoutNodes.keys()]
@@ -283,8 +285,8 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets with clu
   ]
   shuffle(topology) // Pyramid result should be consistent independent of initial order
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
-  const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] })
+  const dataSet = loadData(settings, mockTopology(topology))
+  const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
   layout.processHierarchy({ collapseNodes: true })
 
   const keys = [...layout.layoutNodes.keys()]

--- a/test/visualizer-layout-positioning.test.js
+++ b/test/visualizer-layout-positioning.test.js
@@ -272,6 +272,8 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets', functi
   const expectedSortedIds = topologyToSortedIds(expectedClumpedTopology, false)
   t.deepEqual(layout.getSortedLayoutNodes().map(layoutNode => `${layoutNode.id}`), expectedSortedIds)
 
+  t.ok(layout.ejectedLayoutNodeIds.includes('x2'))
+
   t.end()
 })
 
@@ -308,6 +310,9 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets with clu
 
   const expectedSortedIds = topologyToSortedIds(expectedClumpedTopology, false)
   t.deepEqual(layout.getSortedLayoutNodes().map(layoutNode => `${layoutNode.id}`), expectedSortedIds)
+
+  t.ok(layout.ejectedLayoutNodeIds.includes('x2'))
+  t.ok(layout.ejectedLayoutNodeIds.includes('x3'))
 
   t.end()
 })

--- a/test/visualizer-layout-positioning.test.js
+++ b/test/visualizer-layout-positioning.test.js
@@ -248,9 +248,9 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets', functi
   layout.processHierarchy({ collapseNodes: true })
 
   const keys = [...layout.layoutNodes.keys()]
-  t.deepEqual([ 1, 'x2', 11, 'x', 5, 7, 9, 10, 12 ], keys)
-  t.deepEqual([ 4, 6 ], layout.layoutNodes.get('x').collapsedNodes.map(layoutNode => layoutNode.id))
-  t.deepEqual([ 2, 3, 8 ], layout.layoutNodes.get('x2').collapsedNodes.map(layoutNode => layoutNode.id))
+  t.deepEqual([ 1, 'x3', 11, 'x1', 5, 7, 9, 10, 12 ], keys)
+  t.deepEqual([ 4, 6 ], layout.layoutNodes.get('x1').collapsedNodes.map(layoutNode => layoutNode.id))
+  t.deepEqual([ 2, 3, 8 ], layout.layoutNodes.get('x3').collapsedNodes.map(layoutNode => layoutNode.id))
 
   // Arbitrary Map order being issue here
   // const clumpId = [...layout.layoutNodes.keys()].find(key => ['clump', 2, 3, 8].every(c => ('' + key).includes(c)))
@@ -262,10 +262,10 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets', functi
 
   const expectedClumpedTopology = [
     ['1.12', 50],
-    ['1.x2.x.5', 400],
-    ['1.x2.x.7', 250],
-    ['1.x2.9.10', 200],
-    ['1.x2.11', 100]
+    ['1.x3.x1.5', 400],
+    ['1.x3.x1.7', 250],
+    ['1.x3.9.10', 200],
+    ['1.x3.11', 100]
   ]
   const expectedSortedIds = topologyToSortedIds(expectedClumpedTopology, false)
   t.deepEqual(layout.getSortedLayoutNodes().map(layoutNode => `${layoutNode.id}`), expectedSortedIds)
@@ -288,9 +288,9 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets with clu
   layout.processHierarchy({ collapseNodes: true })
 
   const keys = [...layout.layoutNodes.keys()]
-  t.deepEqual([ 1, 'x3', 11, 'x', 5, 7, 9, 10 ], keys)
-  t.deepEqual([ 4, 6 ], layout.layoutNodes.get('x').collapsedNodes.map(layoutNode => layoutNode.id))
-  t.deepEqual([ 2, 12, 3, 8 ], layout.layoutNodes.get('x3').collapsedNodes.map(layoutNode => layoutNode.id))
+  t.deepEqual([ 1, 'x4', 11, 'x1', 5, 7, 9, 10 ], keys)
+  t.deepEqual([ 4, 6 ], layout.layoutNodes.get('x1').collapsedNodes.map(layoutNode => layoutNode.id))
+  t.deepEqual([ 2, 12, 3, 8 ], layout.layoutNodes.get('x4').collapsedNodes.map(layoutNode => layoutNode.id))
 
   const positioning = layout.positioning
   positioning.formClumpPyramid()
@@ -298,10 +298,10 @@ test('Visualizer layout - positioning - pyramid - can handle collapsets with clu
   t.deepEqual(positioning.order, [5, 7, 10, 11])
 
   const expectedClumpedTopology = [
-    ['1.x3.x.5', 401],
-    ['1.x3.x.7', 250],
-    ['1.x3.9.10', 200],
-    ['1.x3.11', 100]
+    ['1.x4.x1.5', 401],
+    ['1.x4.x1.7', 250],
+    ['1.x4.9.10', 200],
+    ['1.x4.11', 100]
   ]
 
   const expectedSortedIds = topologyToSortedIds(expectedClumpedTopology, false)

--- a/test/visualizer-layout-scale.test.js
+++ b/test/visualizer-layout-scale.test.js
@@ -10,7 +10,12 @@ const { mockTopology } = require('./visualizer-util/fake-topology.js')
 
 const svgWidth = 1000
 const svgHeight = 1000
-const settings = {
+
+const dataSettings = {
+  debugMode: true
+}
+
+const settings = Object.assign({
   svgWidth,
   svgHeight,
   labelMinimumSpace: 0,
@@ -18,7 +23,7 @@ const settings = {
   svgDistanceFromEdge: 30,
   allowStretch: true,
   collapseNodes: false
-}
+}, dataSettings)
 
 test('Visualizer layout - scale - calculates prescale based on longest', function (t) {
   const topology = [
@@ -26,7 +31,7 @@ test('Visualizer layout - scale - calculates prescale based on longest', functio
     ['1.5', svgHeight / 2],
     ['1.2.6', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.ok(layout.scale.prescaleFactor < 2.00 && layout.scale.prescaleFactor > 1.99)
@@ -38,7 +43,7 @@ test('Visualizer layout - scale - calculates scalable line length', function (t)
   const topology = [
     ['1.2', svgHeight]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.ok(isNumber(layout.scale.scaleFactor))
@@ -52,7 +57,7 @@ test('Visualizer layout - scale - calculates scalable circle radius based on len
   const topology = [
     ['1.2', svgHeight]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.ok(isNumber(layout.scale.scaleFactor))
@@ -67,7 +72,7 @@ test('Visualizer layout - scale - demagnifies large shortest', function (t) {
     ['1.2', svgWidth],
     ['1.3', svgWidth * 0.9]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'shortest')
@@ -80,7 +85,7 @@ test('Visualizer layout - scale - demagnifies large longest and stretches height
   const topology = [
     ['1.2.3.4.5.6.7', svgHeight * 3]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'longest')
@@ -94,7 +99,7 @@ test('Visualizer layout - scale - folds small layouts', function (t) {
   const topology = [
     ['1.2', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   const nodesCount = 2
@@ -110,7 +115,7 @@ test('Visualizer layout - scale - constrained longest superseeds other weights',
     ['1.6', svgWidth * 1.51],
     ['1.7', svgWidth * 1.5]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
 
@@ -130,7 +135,7 @@ test('Visualizer layout - scale - constrained longest superseeds other weights (
     ['1.6', svgWidth * 0.5],
     ['1.7', svgWidth * 0.5]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
 
@@ -147,7 +152,7 @@ test('Visualizer layout - scale - demagnifies large diameter (width)', function 
   const topology = [
     ['1.2.3.4.5', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.layoutNodes.get(2).stem.raw.ownDiameter = svgWidth
   layout.updateScale()
@@ -161,7 +166,7 @@ test('Visualizer layout - scale - demagnifies large diameter (height)', function
   const topology = [
     ['1.2.3.4.5.6.7', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const inputHeight = (250 + 30 + 30) * (1 / 1.5)
   const layout = generateLayout(dataSet, Object.assign({}, settings, { svgHeight: inputHeight }))
   layout.layoutNodes.get(2).stem.raw.ownDiameter = 500
@@ -178,7 +183,7 @@ test('Visualizer layout - scale - demagnifies large q50', function (t) {
     ['1.2', (svgWidth / 0.71) + 10],
     ['1.4', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'q50 1-1-sqrt(2) triangle')
@@ -194,7 +199,7 @@ test('Visualizer layout - scale - demagnifies large q25', function (t) {
     ['1.4', (svgWidth / 0.8) + 10],
     ['1.5', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'q25 4-3-5 triangle')
@@ -211,7 +216,7 @@ test('Visualizer layout - scale - demagnifies large q75', function (t) {
     ['1.4', 1],
     ['1.6', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'q75 3-4-5 triangle')
@@ -224,7 +229,7 @@ test('Visualizer layout - scale - magnifies tiny longest', function (t) {
   const topology = [
     ['1.2.3.4.5', svgHeight / 2]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'longest')
@@ -245,9 +250,9 @@ test('Visualizer layout - scale - can handle subsets', function (t) {
     ['1.2.3.4.5.18', svgWidth * 0.34]
   ]
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const subset = [...dataSet.clusterNodes.values()].filter(node => node.id !== 1 && node.id !== 2)
-  const layout = new Layout({ dataNodes: subset })
+  const layout = new Layout({ dataNodes: subset }, dataSettings)
   layout.generate()
 
   t.ok(layout.scale.scaleFactor < 0.33 && layout.scale.scaleFactor > 0.32)
@@ -259,7 +264,7 @@ test('Visualizer layout - scale - demagnifies when absolutes exceed available sp
   const topology = [
     ['1.2.3.4.5.6.7.8.9.10.11', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, { svgWidth: 100, svgHeight: 100, svgDistanceFromEdge: 5, labelMinimumSpace: 20, lineWidth: 30, collapseNodes: false })
   layout.updateScale()
   t.equal(layout.scale.decisiveWeight.category, 'longest')
@@ -276,7 +281,7 @@ test('Visualizer layout - scale - can handle zero-sized nodes', function (t) {
     ['1.4', 1]
   ]
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.layoutNodes.get(1).stem.raw.ownDiameter = 0
   layout.layoutNodes.get(2).stem.lengths.scalable = 0
@@ -294,7 +299,7 @@ test('Visualizer layout - scale - can handle zero-sized views', function (t) {
     ['1.4', 0]
   ]
 
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const layout = generateLayout(dataSet, settings)
   layout.layoutNodes.get(1).stem.raw.ownDiameter = 0
   layout.layoutNodes.get(2).stem.lengths.scalable = 0

--- a/test/visualizer-layout.test.js
+++ b/test/visualizer-layout.test.js
@@ -75,7 +75,7 @@ test('Visualizer layout - collapse - collapses vertically (except root and Ps)',
   layout.processBetweenData()
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
-  t.deepEqual(actualAfter, ['1 => clump:C2,C3', 'clump:C2,C3 => 4', '4 => 5', '5 => '])
+  t.deepEqual(actualAfter, ['1 => x', 'x => 4', '4 => 5', '5 => '])
 
   t.end()
 })
@@ -114,14 +114,14 @@ test('Visualizer layout - collapse - merges shortcuts pointing to the same view'
   const initialLayout = new Layout({ dataNodes: initialDataNodes }, settings)
   initialLayout.processHierarchy()
   let toValidLink = createLinkValidator(initialLayout)
-  t.deepEqual([...initialLayout.layoutNodes.values()].map(toTypeId), ['ClusterNode-1', 'ClusterNode-2', 'ClusterNode-3', 'ArtificialNode-clump:C4,C6,C8', 'ClusterNode-5', 'ClusterNode-7', 'ClusterNode-9'])
-  t.deepEqual([...initialLayout.layoutNodes.values()].map(toValidLink), ['1 => 2', '2 => 3', '3 => clump:C4,C6,C8', 'clump:C4,C6,C8 => 5;7;9', '5 => ', '7 => ', '9 => '])
+  t.deepEqual([...initialLayout.layoutNodes.values()].map(toTypeId), ['ClusterNode-1', 'ClusterNode-2', 'ClusterNode-3', 'ArtificialNode-x1', 'ClusterNode-5', 'ClusterNode-7', 'ClusterNode-9'])
+  t.deepEqual([...initialLayout.layoutNodes.values()].map(toValidLink), ['1 => 2', '2 => 3', '3 => x1', 'x1 => 5;7;9', '5 => ', '7 => ', '9 => '])
   const traversedLayoutNode = initialLayout.layoutNodes.get(3)
   const traversedLayout = initialLayout.createSubLayout(traversedLayoutNode, settings)
   traversedLayout.processHierarchy()
   toValidLink = createLinkValidator(traversedLayout)
-  t.deepEqual([...traversedLayout.layoutNodes.values()].map(toTypeId), ['ShortcutNode-shortcut:2', 'AggregateNode-3', 'ShortcutNode-shortcut:clump:C4,C6,C8'])
-  t.deepEqual([...traversedLayout.layoutNodes.values()].map(toValidLink), ['shortcut:2 => 3', '3 => shortcut:clump:C4,C6,C8', 'shortcut:clump:C4,C6,C8 => '])
+  t.deepEqual([...traversedLayout.layoutNodes.values()].map(toTypeId), ['ShortcutNode-shortcut:2', 'AggregateNode-3', 'ShortcutNode-shortcut:x1'])
+  t.deepEqual([...traversedLayout.layoutNodes.values()].map(toValidLink), ['shortcut:2 => 3', '3 => shortcut:x1', 'shortcut:x1 => '])
 
   t.end()
 })
@@ -145,7 +145,7 @@ test('Visualizer layout - collapse - collapses vertically with break (except roo
   layout.processBetweenData()
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
-  t.deepEqual(actualAfter, ['1 => clump:C2,C3', 'clump:C2,C3 => 4', '4 => 5', '5 => clump:C6,C7', 'clump:C6,C7 => 8', '8 => 9', '9 => '])
+  t.deepEqual(actualAfter, ['1 => x1', 'x1 => 4', '4 => 5', '5 => x', 'x => 8', '8 => 9', '9 => '])
 
   t.end()
 })
@@ -169,7 +169,7 @@ test('Visualizer layout - collapse - collapses vertically until minimum count th
   layout.processBetweenData()
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
-  t.deepEqual(actualAfter, ['1 => 2', '2 => clump:C3,C4,C5,C6', 'clump:C3,C4,C5,C6 => '])
+  t.deepEqual(actualAfter, ['1 => 2', '2 => x', 'x => '])
 
   t.end()
 })
@@ -201,7 +201,7 @@ test('Visualizer layout - collapse - collapses horizontally', function (t) {
   layout.processBetweenData()
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
-  t.deepEqual(actualAfter, ['1 => 2', '2 => clump:C3,C7;5', 'clump:C3,C7 => 4;8', '4 => ', '8 => ', '5 => 6', '6 => '])
+  t.deepEqual(actualAfter, ['1 => 2', '2 => x;5', 'x => 4;8', '4 => ', '8 => ', '5 => 6', '6 => '])
 
   t.end()
 })
@@ -230,7 +230,7 @@ test('Visualizer layout - collapse - collapses both horizontally and vertically 
   layout.processBetweenData()
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
-  t.deepEqual(actualAfter, ['1 => clump:C2,C3,C6', 'clump:C2,C3,C6 => 4;7', '4 => 5', '5 => ', '7 => 8', '8 => '])
+  t.deepEqual(actualAfter, ['1 => x1', 'x1 => 4;7', '4 => 5', '5 => ', '7 => 8', '8 => '])
 
   t.end()
 })
@@ -262,8 +262,8 @@ test('Visualizer layout - collapse - vertically collapses subset with missing ro
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
   const sortedAfter = layout.getSortedLayoutNodes().map(toValidLink)
-  t.deepEqual(actualAfter, ['2 => clump:C3,C4', 'clump:C3,C4 => 5', '5 => 6', '6 => ', '7 => 8', '8 => 9', '9 => 10', '10 => '])
-  t.deepEqual(sortedAfter, ['2 => clump:C3,C4', '7 => 8', 'clump:C3,C4 => 5', '8 => 9', '5 => 6', '9 => 10', '6 => ', '10 => '])
+  t.deepEqual(actualAfter, ['2 => x', 'x => 5', '5 => 6', '6 => ', '7 => 8', '8 => 9', '9 => 10', '10 => '])
+  t.deepEqual(sortedAfter, ['2 => x', '7 => 8', 'x => 5', '8 => 9', '5 => 6', '9 => 10', '6 => ', '10 => '])
 
   t.end()
 })
@@ -291,7 +291,7 @@ test('Visualizer layout - collapse - collapses subset both vertically and horizo
   layout.processBetweenData()
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
-  t.deepEqual(actualAfter, ['1 => 2', '2 => clump:C3,C4,C6', 'clump:C3,C4,C6 => 7', '7 => '])
+  t.deepEqual(actualAfter, ['1 => 2', '2 => x1', 'x1 => 7', '7 => '])
 
   t.end()
 })
@@ -333,7 +333,7 @@ test('Visualizer layout - collapse - complex example', function (t) {
   layout.processBetweenData()
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
-  t.deepEqual(actualAfter, ['1 => 2;3', '2 => ', '3 => clump:C4,C5,C6,C7,C8,C9;10', 'clump:C4,C5,C6,C7,C8,C9 => ', '10 => clump:C11,C12,C13', 'clump:C11,C12,C13 => '])
+  t.deepEqual(actualAfter, ['1 => 2;3', '2 => ', '3 => x2;10', 'x2 => ', '10 => x1', 'x1 => '])
 
   t.end()
 })

--- a/test/visualizer-layout.test.js
+++ b/test/visualizer-layout.test.js
@@ -80,6 +80,7 @@ test('Visualizer layout - collapse - collapses vertically (except root and Ps)',
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
   t.deepEqual(actualAfter, ['1 => x1', 'x1 => 4', '4 => 5', '5 => '])
+  t.deepEqual([ 2, 3 ], layout.layoutNodes.get('x1').collapsedNodes.map(layoutNode => layoutNode.id))
 
   t.end()
 })
@@ -151,6 +152,8 @@ test('Visualizer layout - collapse - collapses vertically with break (except roo
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
   t.deepEqual(actualAfter, ['1 => x2', 'x2 => 4', '4 => 5', '5 => x1', 'x1 => 8', '8 => 9', '9 => '])
+  t.deepEqual([ 6, 7 ], layout.layoutNodes.get('x1').collapsedNodes.map(layoutNode => layoutNode.id))
+  t.deepEqual([ 2, 3 ], layout.layoutNodes.get('x2').collapsedNodes.map(layoutNode => layoutNode.id))
 
   t.end()
 })
@@ -175,6 +178,7 @@ test('Visualizer layout - collapse - collapses vertically until minimum count th
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
   t.deepEqual(actualAfter, ['1 => 2', '2 => x1', 'x1 => '])
+  t.deepEqual([ 3, 4, 5, 6 ], layout.layoutNodes.get('x1').collapsedNodes.map(layoutNode => layoutNode.id))
 
   t.end()
 })
@@ -207,6 +211,7 @@ test('Visualizer layout - collapse - collapses horizontally', function (t) {
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
   t.deepEqual(actualAfter, ['1 => 2', '2 => x1;5', 'x1 => 4;8', '4 => ', '8 => ', '5 => 6', '6 => '])
+  t.deepEqual([ 3, 7 ], layout.layoutNodes.get('x1').collapsedNodes.map(layoutNode => layoutNode.id))
 
   t.end()
 })
@@ -236,6 +241,8 @@ test('Visualizer layout - collapse - collapses both horizontally and vertically 
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
   t.deepEqual(actualAfter, ['1 => x2', 'x2 => 4;7', '4 => 5', '5 => ', '7 => 8', '8 => '])
+  t.deepEqual([ 2, 3, 6 ], layout.layoutNodes.get('x2').collapsedNodes.map(layoutNode => layoutNode.id))
+
   t.ok(layout.ejectedLayoutNodeIds.includes('x1'))
 
   t.end()
@@ -270,6 +277,7 @@ test('Visualizer layout - collapse - vertically collapses subset with missing ro
   const sortedAfter = layout.getSortedLayoutNodes().map(toValidLink)
   t.deepEqual(actualAfter, ['2 => x1', 'x1 => 5', '5 => 6', '6 => ', '7 => 8', '8 => 9', '9 => 10', '10 => '])
   t.deepEqual(sortedAfter, ['2 => x1', '7 => 8', 'x1 => 5', '8 => 9', '5 => 6', '9 => 10', '6 => ', '10 => '])
+  t.deepEqual([ 3, 4 ], layout.layoutNodes.get('x1').collapsedNodes.map(layoutNode => layoutNode.id))
 
   t.end()
 })
@@ -286,7 +294,7 @@ test('Visualizer layout - collapse - collapses subset both vertically and horizo
   const dataSet = loadData(dataSettings, mockTopology(topology))
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   dataSet.clusterNodes.get(7).stats.async.between = 100 // make 7 long
-  const subset = [1, 2, 3, 4, 6, 7].map(nodeId => dataSet.clusterNodes.get(nodeId))
+  const subset = [1, 2, 3, 4, 6, 7].map(nodeId => dataSet.clusterNodes.get(nodeId)) // drop 5 and 8
   const layout = new Layout({ dataNodes: subset }, settings)
   layout.processBetweenData()
   layout.updateScale()
@@ -298,6 +306,7 @@ test('Visualizer layout - collapse - collapses subset both vertically and horizo
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
   t.deepEqual(actualAfter, ['1 => 2', '2 => x2', 'x2 => 7', '7 => '])
+  t.deepEqual([ 3, 6, 4 ], layout.layoutNodes.get('x2').collapsedNodes.map(layoutNode => layoutNode.id))
   t.ok(layout.ejectedLayoutNodeIds.includes('x1'))
 
   t.end()
@@ -341,6 +350,9 @@ test('Visualizer layout - collapse - complex example', function (t) {
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
   t.deepEqual(actualAfter, ['1 => 2;3', '2 => ', '3 => x3;10', 'x3 => ', '10 => x2', 'x2 => '])
+  t.deepEqual([ 11, 12, 13 ], layout.layoutNodes.get('x2').collapsedNodes.map(layoutNode => layoutNode.id))
+  t.deepEqual([ 4, 5, 7, 6, 8, 9 ], layout.layoutNodes.get('x3').collapsedNodes.map(layoutNode => layoutNode.id))
+
   t.ok(layout.ejectedLayoutNodeIds.includes('x1'))
 
   t.end()

--- a/test/visualizer-layout.test.js
+++ b/test/visualizer-layout.test.js
@@ -126,6 +126,7 @@ test('Visualizer layout - collapse - merges shortcuts pointing to the same view'
   toValidLink = createLinkValidator(traversedLayout)
   t.deepEqual([...traversedLayout.layoutNodes.values()].map(toTypeId), ['ShortcutNode-shortcut:2', 'AggregateNode-3', 'ShortcutNode-shortcut:x2'])
   t.deepEqual([...traversedLayout.layoutNodes.values()].map(toValidLink), ['shortcut:2 => 3', '3 => shortcut:x2', 'shortcut:x2 => '])
+  t.ok(initialLayout.ejectedLayoutNodeIds.includes('x1'))
 
   t.end()
 })
@@ -235,6 +236,7 @@ test('Visualizer layout - collapse - collapses both horizontally and vertically 
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
   t.deepEqual(actualAfter, ['1 => x2', 'x2 => 4;7', '4 => 5', '5 => ', '7 => 8', '8 => '])
+  t.ok(layout.ejectedLayoutNodeIds.includes('x1'))
 
   t.end()
 })
@@ -296,6 +298,7 @@ test('Visualizer layout - collapse - collapses subset both vertically and horizo
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
   t.deepEqual(actualAfter, ['1 => 2', '2 => x2', 'x2 => 7', '7 => '])
+  t.ok(layout.ejectedLayoutNodeIds.includes('x1'))
 
   t.end()
 })
@@ -338,6 +341,7 @@ test('Visualizer layout - collapse - complex example', function (t) {
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
   t.deepEqual(actualAfter, ['1 => 2;3', '2 => ', '3 => x3;10', 'x3 => ', '10 => x2', 'x2 => '])
+  t.ok(layout.ejectedLayoutNodeIds.includes('x1'))
 
   t.end()
 })

--- a/test/visualizer-layout.test.js
+++ b/test/visualizer-layout.test.js
@@ -27,20 +27,24 @@ function toTypeId (layoutNode) {
   return layoutNode.node.constructor.name + '-' + layoutNode.id
 }
 
-const settings = {
+const dataSettings = {
+  debugMode: true
+}
+
+const settings = Object.assign({
   svgWidth: 1000,
   svgHeight: 1000,
   labelMinimumSpace: 0,
   lineWidth: 0,
   svgDistanceFromEdge: 30,
   collapseNodes: true
-}
+}, dataSettings)
 
 test('Visualizer layout - builds sublayout from connection', function (t) {
   const topology = [
     ['1.2.3.4.5', 100]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const initialDataNodes = [...dataSet.clusterNodes.values()]
   const uncollapsedSettings = Object.assign({ collapseNodes: false }, settings)
   const initialLayout = new Layout({ dataNodes: initialDataNodes }, uncollapsedSettings)
@@ -62,7 +66,7 @@ test('Visualizer layout - collapse - collapses vertically (except root and Ps)',
   const topology = [
     ['1.2.3.4.5', 100]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   const layout = new Layout({ dataNodes }, settings)
@@ -86,7 +90,7 @@ test('Visualizer layout - collapse - does not collapse shortcut nodes', function
     ['1.2.4', 1],
     ['1.2.5', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const initialDataNodes = [...dataSet.clusterNodes.values()]
   const initialLayout = new Layout({ dataNodes: initialDataNodes }, settings)
   initialLayout.processHierarchy()
@@ -104,7 +108,7 @@ test('Visualizer layout - collapse - merges shortcuts pointing to the same view'
     ['1.2.3.6.7', 1],
     ['1.2.3.8.9', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const initialDataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(2).stats.async.between = 100 // make 2 long
   dataSet.clusterNodes.get(3).stats.async.between = 100 // make 3 long
@@ -131,7 +135,7 @@ test('Visualizer layout - collapse - collapses vertically with break (except roo
   const topology = [
     ['1.2.3.4.5.6.7.8.9', 100]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   dataSet.clusterNodes.get(5).stats.async.between = 100 // make 5 long
@@ -156,7 +160,7 @@ test('Visualizer layout - collapse - collapses vertically until minimum count th
     ['1.2.3.4.5', 1],
     ['1.2.3.4.6', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1000 // make root long
   const layout = new Layout({ dataNodes }, settings)
@@ -187,7 +191,7 @@ test('Visualizer layout - collapse - collapses horizontally', function (t) {
     ['1.2.5.6', 100],
     ['1.2.7.8', 100]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(2).stats.async.between = 100 // make 2 long
   dataSet.clusterNodes.get(5).stats.async.between = 100 // make 5 long
@@ -217,7 +221,7 @@ test('Visualizer layout - collapse - collapses both horizontally and vertically 
     ['1.2.3.4.5', 100],
     ['1.2.6.7.8', 100]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   const layout = new Layout({ dataNodes }, settings)
@@ -245,7 +249,7 @@ test('Visualizer layout - collapse - vertically collapses subset with missing ro
     ['1.2.3.4.5.6', 100],
     ['1.7.8.9.10', 100]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   dataSet.clusterNodes.get(9).stats.async.within = 100 // make 9 long
   const subset = [2, 3, 4, 5, 6, 7, 8, 9, 10].map(nodeId => dataSet.clusterNodes.get(nodeId))
   const layout = new Layout({ dataNodes: subset }, settings)
@@ -277,7 +281,7 @@ test('Visualizer layout - collapse - collapses subset both vertically and horizo
     ['1.2.3.4.5', 100],
     ['1.2.6.7.8', 100]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   dataSet.clusterNodes.get(7).stats.async.between = 100 // make 7 long
   const subset = [1, 2, 3, 4, 6, 7].map(nodeId => dataSet.clusterNodes.get(nodeId))
@@ -317,7 +321,7 @@ test('Visualizer layout - collapse - complex example', function (t) {
     ['1.3.10.11', 1],
     ['1.3.10.12.13', 1]
   ]
-  const dataSet = loadData({ debugMode: true }, mockTopology(topology))
+  const dataSet = loadData(dataSettings, mockTopology(topology))
   const dataNodes = [...dataSet.clusterNodes.values()]
   dataSet.clusterNodes.get(1).stats.async.within = 1 // make root short
   dataSet.clusterNodes.get(2).stats.async.within = 100 // make 2 long

--- a/test/visualizer-layout.test.js
+++ b/test/visualizer-layout.test.js
@@ -75,7 +75,7 @@ test('Visualizer layout - collapse - collapses vertically (except root and Ps)',
   layout.processBetweenData()
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
-  t.deepEqual(actualAfter, ['1 => x', 'x => 4', '4 => 5', '5 => '])
+  t.deepEqual(actualAfter, ['1 => x1', 'x1 => 4', '4 => 5', '5 => '])
 
   t.end()
 })
@@ -114,14 +114,14 @@ test('Visualizer layout - collapse - merges shortcuts pointing to the same view'
   const initialLayout = new Layout({ dataNodes: initialDataNodes }, settings)
   initialLayout.processHierarchy()
   let toValidLink = createLinkValidator(initialLayout)
-  t.deepEqual([...initialLayout.layoutNodes.values()].map(toTypeId), ['ClusterNode-1', 'ClusterNode-2', 'ClusterNode-3', 'ArtificialNode-x1', 'ClusterNode-5', 'ClusterNode-7', 'ClusterNode-9'])
-  t.deepEqual([...initialLayout.layoutNodes.values()].map(toValidLink), ['1 => 2', '2 => 3', '3 => x1', 'x1 => 5;7;9', '5 => ', '7 => ', '9 => '])
+  t.deepEqual([...initialLayout.layoutNodes.values()].map(toTypeId), ['ClusterNode-1', 'ClusterNode-2', 'ClusterNode-3', 'ArtificialNode-x2', 'ClusterNode-5', 'ClusterNode-7', 'ClusterNode-9'])
+  t.deepEqual([...initialLayout.layoutNodes.values()].map(toValidLink), ['1 => 2', '2 => 3', '3 => x2', 'x2 => 5;7;9', '5 => ', '7 => ', '9 => '])
   const traversedLayoutNode = initialLayout.layoutNodes.get(3)
   const traversedLayout = initialLayout.createSubLayout(traversedLayoutNode, settings)
   traversedLayout.processHierarchy()
   toValidLink = createLinkValidator(traversedLayout)
-  t.deepEqual([...traversedLayout.layoutNodes.values()].map(toTypeId), ['ShortcutNode-shortcut:2', 'AggregateNode-3', 'ShortcutNode-shortcut:x1'])
-  t.deepEqual([...traversedLayout.layoutNodes.values()].map(toValidLink), ['shortcut:2 => 3', '3 => shortcut:x1', 'shortcut:x1 => '])
+  t.deepEqual([...traversedLayout.layoutNodes.values()].map(toTypeId), ['ShortcutNode-shortcut:2', 'AggregateNode-3', 'ShortcutNode-shortcut:x2'])
+  t.deepEqual([...traversedLayout.layoutNodes.values()].map(toValidLink), ['shortcut:2 => 3', '3 => shortcut:x2', 'shortcut:x2 => '])
 
   t.end()
 })
@@ -145,7 +145,7 @@ test('Visualizer layout - collapse - collapses vertically with break (except roo
   layout.processBetweenData()
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
-  t.deepEqual(actualAfter, ['1 => x1', 'x1 => 4', '4 => 5', '5 => x', 'x => 8', '8 => 9', '9 => '])
+  t.deepEqual(actualAfter, ['1 => x2', 'x2 => 4', '4 => 5', '5 => x1', 'x1 => 8', '8 => 9', '9 => '])
 
   t.end()
 })
@@ -169,7 +169,7 @@ test('Visualizer layout - collapse - collapses vertically until minimum count th
   layout.processBetweenData()
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
-  t.deepEqual(actualAfter, ['1 => 2', '2 => x', 'x => '])
+  t.deepEqual(actualAfter, ['1 => 2', '2 => x1', 'x1 => '])
 
   t.end()
 })
@@ -201,7 +201,7 @@ test('Visualizer layout - collapse - collapses horizontally', function (t) {
   layout.processBetweenData()
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
-  t.deepEqual(actualAfter, ['1 => 2', '2 => x;5', 'x => 4;8', '4 => ', '8 => ', '5 => 6', '6 => '])
+  t.deepEqual(actualAfter, ['1 => 2', '2 => x1;5', 'x1 => 4;8', '4 => ', '8 => ', '5 => 6', '6 => '])
 
   t.end()
 })
@@ -230,7 +230,7 @@ test('Visualizer layout - collapse - collapses both horizontally and vertically 
   layout.processBetweenData()
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
-  t.deepEqual(actualAfter, ['1 => x1', 'x1 => 4;7', '4 => 5', '5 => ', '7 => 8', '8 => '])
+  t.deepEqual(actualAfter, ['1 => x2', 'x2 => 4;7', '4 => 5', '5 => ', '7 => 8', '8 => '])
 
   t.end()
 })
@@ -262,8 +262,8 @@ test('Visualizer layout - collapse - vertically collapses subset with missing ro
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
   const sortedAfter = layout.getSortedLayoutNodes().map(toValidLink)
-  t.deepEqual(actualAfter, ['2 => x', 'x => 5', '5 => 6', '6 => ', '7 => 8', '8 => 9', '9 => 10', '10 => '])
-  t.deepEqual(sortedAfter, ['2 => x', '7 => 8', 'x => 5', '8 => 9', '5 => 6', '9 => 10', '6 => ', '10 => '])
+  t.deepEqual(actualAfter, ['2 => x1', 'x1 => 5', '5 => 6', '6 => ', '7 => 8', '8 => 9', '9 => 10', '10 => '])
+  t.deepEqual(sortedAfter, ['2 => x1', '7 => 8', 'x1 => 5', '8 => 9', '5 => 6', '9 => 10', '6 => ', '10 => '])
 
   t.end()
 })
@@ -291,7 +291,7 @@ test('Visualizer layout - collapse - collapses subset both vertically and horizo
   layout.processBetweenData()
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
-  t.deepEqual(actualAfter, ['1 => 2', '2 => x1', 'x1 => 7', '7 => '])
+  t.deepEqual(actualAfter, ['1 => 2', '2 => x2', 'x2 => 7', '7 => '])
 
   t.end()
 })
@@ -333,7 +333,7 @@ test('Visualizer layout - collapse - complex example', function (t) {
   layout.processBetweenData()
   layout.updateScale()
   const actualAfter = [...layout.layoutNodes.values()].map(toValidLink)
-  t.deepEqual(actualAfter, ['1 => 2;3', '2 => ', '3 => x2;10', 'x2 => ', '10 => x1', 'x1 => '])
+  t.deepEqual(actualAfter, ['1 => 2;3', '2 => ', '3 => x3;10', 'x3 => ', '10 => x2', 'x2 => '])
 
   t.end()
 })

--- a/test/visualizer-validation.test.js
+++ b/test/visualizer-validation.test.js
@@ -79,6 +79,12 @@ test('Visualizer validation - uniqueMapKey', function (t) {
   t.equals(uniqueMapKey(objectKey, testMap), '[object Object]_1')
   t.equals(uniqueMapKey(objectKey2, testMap), objectKey2)
 
+  t.equals(uniqueMapKey('a', testMap, '', 1), 'a1')
+  t.equals(uniqueMapKey('b', testMap, '_', 1), 'b_2')
+  t.equals(uniqueMapKey('b', testMap, '_', 2), 'b_2')
+  t.equals(uniqueMapKey('b', testMap, '_', 3), 'b_3')
+  t.equals(uniqueMapKey('c', testMap, '--', 1), 'c--1')
+
   testMap.set(uniqueMapKey('a', testMap), 6)
   t.equals(uniqueMapKey('a', testMap), 'a_2')
 
@@ -99,6 +105,12 @@ test('Visualizer validation - uniqueObjectKey', function (t) {
   t.equals(uniqueObjectKey('a', testObject), 'a_1')
   t.equals(uniqueObjectKey('b', testObject), 'b_2')
   t.equals(uniqueObjectKey(99, testObject), '99_1')
+
+  t.equals(uniqueObjectKey('a', testObject, '', 1), 'a1')
+  t.equals(uniqueObjectKey('b', testObject, '_', 1), 'b_2')
+  t.equals(uniqueObjectKey('b', testObject, '_', 2), 'b_2')
+  t.equals(uniqueObjectKey('b', testObject, '_', 3), 'b_3')
+  t.equals(uniqueObjectKey('c', testObject, '--', 1), 'c--1')
 
   testObject[uniqueObjectKey('a', testObject)] = 5
   t.equals(uniqueObjectKey('a', testObject), 'a_2')

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -85,6 +85,8 @@ class BubbleprofUI extends EventEmitter {
 
   getSettingsForLayout () {
     const settings = {}
+    if (this.dataSet && this.dataSet.settings.debugMode) settings.debugMode = true
+
     switch (this.settings.viewMode) {
       case 'fit':
       case 'maximised':

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -358,43 +358,39 @@ class BubbleprofUI extends EventEmitter {
   }
 
   generateCollapsedNodeHash (uiWithinCollapsedNode) {
-    let hash = `l${uiWithinCollapsedNode.layoutNode.id}|`
+    let hashString = uiWithinCollapsedNode.layoutNode.id
     const appendParentNode = (parentUI) => {
-      if (!parentUI.layoutNode) {
-        hash += 'm'
-      } else {
+      if (parentUI.layoutNode) {
         const dataNode = parentUI.layoutNode.node
         switch (dataNode.constructor.name) {
           case 'ClusterNode':
-            hash += 'c' + dataNode.clusterId
+            hashString += '-c' + dataNode.clusterId
             break
           case 'ArtificialNode':
-            hash += `l${parentUI.layoutNode.id}|`
+            hashString += `-${parentUI.layoutNode.id}`
             appendParentNode(parentUI.parentUI)
             break
         }
       }
     }
     appendParentNode(uiWithinCollapsedNode.parentUI)
-    return hash
+    return hashString
   }
 
   parseCollapsedNodeHash () {
-    const nodeIds = window.location.hash.slice(1).split('|')
-    const lastNodeId = nodeIds.pop()
-    let targetUI
-    if (lastNodeId === 'm') {
-      targetUI = this
-    } else {
-      const clusterId = parseInt(lastNodeId.slice(1))
-      const clusterNode = this.dataSet.clusterNodes.get(clusterId)
-      targetUI = this.jumpToNode(clusterNode)
-    }
+    const nodeIds = window.location.hash.slice(1).split('-')
+    let targetUI = this
 
     for (var i = nodeIds.length - 1; i >= 0; i--) {
-      const layoutNodeId = nodeIds[i].slice(1)
-      const layoutNode = targetUI.layout.layoutNodes.get(layoutNodeId)
-      targetUI = targetUI.selectNode(layoutNode)
+      const nodeId = nodeIds[i]
+      if (nodeId.charAt(0) === 'x') {
+        const layoutNode = targetUI.layout.layoutNodes.get(nodeId)
+        targetUI = targetUI.selectNode(layoutNode)
+      } else {
+        const clusterId = parseInt(nodeId.slice(1))
+        const clusterNode = this.dataSet.clusterNodes.get(clusterId)
+        targetUI = targetUI.jumpToNode(clusterNode)
+      }
     }
     this.emit('navigation', { from: this, to: targetUI })
   }
@@ -582,7 +578,7 @@ class BubbleprofUI extends EventEmitter {
             const uiWithinCluster = this.jumpToNode(clusterNode)
             this.emit('navigation', { from: this, to: uiWithinCluster })
             break
-          case 'l':
+          case 'x':
             this.parseCollapsedNodeHash(window.location.hash)
             break
         }

--- a/visualizer/layout/collapsed-layout.js
+++ b/visualizer/layout/collapsed-layout.js
@@ -18,6 +18,9 @@ class CollapsedLayout {
     this.scale = layout.scale
     this.minimumNodes = 3
 
+    // If debugging, expose one pool of ejected node IDs that is added to each time this class is initialized
+    if (layout.settings.debugMode && !layout.ejectedLayoutNodeIds) layout.ejectedLayoutNodeIds = []
+
     // TODO: stop relying on coincidental Map.keys() order (i.e. stuff would break when child occurs before parent)
     // e.g. we could attach .topNodes or some iterator to Layout instances
     this.topLayoutNodes = new Set([...this.layoutNodes.values()].filter(layoutNode => !layoutNode.parent))
@@ -179,8 +182,13 @@ class CollapsedLayout {
 
     // Update refs
     ejectLayoutNode(parent, hostNode)
+    if (this.uncollapsedLayout.settings.debugMode) this.uncollapsedLayout.ejectedLayoutNodeIds.push(hostNode.id)
+
     ejectLayoutNode(parent, squashNode)
+    if (this.uncollapsedLayout.settings.debugMode) this.uncollapsedLayout.ejectedLayoutNodeIds.push(squashNode.id)
+
     insertLayoutNode(this.layoutNodes, parent, collapsed)
+
     // Update indices
     this.layoutNodes.set(collapsed.id, collapsed)
     this.layoutNodes.delete(hostNode.id)

--- a/visualizer/layout/collapsed-layout.js
+++ b/visualizer/layout/collapsed-layout.js
@@ -174,7 +174,7 @@ class CollapsedLayout {
 
     const collapsedNodes = hostNodes.concat(squashNodes).sort(this.uncollapsedLayout.getLayoutNodeSorter())
 
-    const collapsedId = uniqueMapKey('x', this.layoutNodes, '')
+    const collapsedId = uniqueMapKey('x', this.layoutNodes, '', 1)
     const collapsed = new CollapsedLayoutNode(collapsedId, collapsedNodes, parent, children)
 
     // Update refs

--- a/visualizer/layout/collapsed-layout.js
+++ b/visualizer/layout/collapsed-layout.js
@@ -7,6 +7,8 @@ const _ = {
 const { ShortcutNode } = require('../data/data-node.js')
 const { LayoutNode, CollapsedLayoutNode } = require('./layout-node.js')
 
+const { uniqueMapKey } = require('../validation.js')
+
 class CollapsedLayout {
   constructor (layout) {
     this.uncollapsedLayout = layout
@@ -171,7 +173,9 @@ class CollapsedLayout {
     const squashNodes = squashNode.collapsedNodes ? [...squashNode.collapsedNodes] : [squashNode]
 
     const collapsedNodes = hostNodes.concat(squashNodes).sort(this.uncollapsedLayout.getLayoutNodeSorter())
-    const collapsed = new CollapsedLayoutNode(collapsedNodes, parent, children)
+
+    const collapsedId = uniqueMapKey('x', this.layoutNodes, '')
+    const collapsed = new CollapsedLayoutNode(collapsedId, collapsedNodes, parent, children)
 
     // Update refs
     ejectLayoutNode(parent, hostNode)

--- a/visualizer/layout/index.js
+++ b/visualizer/layout/index.js
@@ -3,6 +3,9 @@
 const Layout = require('./layout.js')
 
 function generateLayout (dataSet, settings) {
+  settings = Object.assign({
+    debugMode: dataSet.settings.debugMode
+  }, settings)
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, settings)
 
   // This can be interrupted in tests etc

--- a/visualizer/layout/layout-node.js
+++ b/visualizer/layout/layout-node.js
@@ -28,17 +28,12 @@ class LayoutNode {
 }
 
 class CollapsedLayoutNode {
-  constructor (layoutNodes, parent, children) {
+  constructor (collapsedId, layoutNodes, parent, children) {
     // layoutNodes should be an array sorted using layout.getLayoutNodeSorter()
     const dataNodes = layoutNodes.map(layoutNode => layoutNode.node)
 
     // Collapsed ids are for uniqueness and human inspection; sort ids into a human-readable order
-    this.id = 'clump:' + dataNodes.map(dataNode => dataNode.uid).sort((a, b) => {
-      if (a.charAt(0) !== b.charAt(0)) {
-        return a.charAt(0) > b.charAt(0) ? 1 : -1
-      }
-      return parseInt(a.slice(1)) - parseInt(b.slice(1))
-    }).join(',')
+    this.id = collapsedId
 
     this.collapsedNodes = layoutNodes
     this.parent = parent

--- a/visualizer/layout/layout.js
+++ b/visualizer/layout/layout.js
@@ -18,7 +18,8 @@ class Layout {
       svgWidth: 750,
       svgHeight: 750,
       shortcutLength: 60,
-      allowStretch: true
+      allowStretch: true,
+      debugMode: false
     }
     this.settings = Object.assign(defaultSettings, settings)
     this.initialInput = {

--- a/visualizer/layout/positioning.js
+++ b/visualizer/layout/positioning.js
@@ -19,8 +19,9 @@ class Positioning {
     this.order = clumpPyramid.order
   }
   placeNodes () {
-    this.nodeAllocation = new NodeAllocation(this.layout, this.layoutNodes)
-    this.nodeAllocation.process()
+    const nodeAllocation = new NodeAllocation(this.layout, this.layoutNodes)
+    nodeAllocation.process()
+    if (this.layout.settings.debugMode) this.nodeAllocation = nodeAllocation
   }
   debugInspect () {
     const intoOrder = (leafA, leafB) => this.order.indexOf(leafA.id) - this.order.indexOf(leafB.id)

--- a/visualizer/validation.js
+++ b/visualizer/validation.js
@@ -36,17 +36,18 @@ function validateNumber (num, targetDescription = '', conditions = {}) {
   return num
 }
 
-function uniqueMapKey (key, map, separator) {
+function uniqueMapKey (key, map, separator, startingNum = 0) {
   const test = (key) => !map.has(key)
-  return incrementKeyUntilUnique(key, 0, test, separator)
+  return incrementKeyUntilUnique(key, startingNum, test, separator)
 }
 
-function uniqueObjectKey (key, object, separator) {
+function uniqueObjectKey (key, object, separator, startingNum = 0) {
   const test = (key) => typeof object[key] === 'undefined'
-  return incrementKeyUntilUnique(key, 0, test, separator)
+  return incrementKeyUntilUnique(key, startingNum, test, separator)
 }
 
-function incrementKeyUntilUnique (key, counter, test, separator = '_') {
+function incrementKeyUntilUnique (key, counter, test, separator = '_', startAt = null) {
+  if (!key && startAt !== null) key = startAt
   const testKey = counter ? `${key}${separator}${counter}` : key
   return test(testKey) ? testKey : incrementKeyUntilUnique(key, counter + 1, test, separator)
 }

--- a/visualizer/validation.js
+++ b/visualizer/validation.js
@@ -36,19 +36,19 @@ function validateNumber (num, targetDescription = '', conditions = {}) {
   return num
 }
 
-function uniqueMapKey (key, map) {
+function uniqueMapKey (key, map, separator) {
   const test = (key) => !map.has(key)
-  return incrementKeyUntilUnique(key, 0, test)
+  return incrementKeyUntilUnique(key, 0, test, separator)
 }
 
-function uniqueObjectKey (key, object) {
+function uniqueObjectKey (key, object, separator) {
   const test = (key) => typeof object[key] === 'undefined'
-  return incrementKeyUntilUnique(key, 0, test)
+  return incrementKeyUntilUnique(key, 0, test, separator)
 }
 
-function incrementKeyUntilUnique (key, counter, test) {
-  const testKey = counter ? `${key}_${counter}` : key
-  return test(testKey) ? testKey : incrementKeyUntilUnique(key, counter + 1, test)
+function incrementKeyUntilUnique (key, counter, test, separator = '_') {
+  const testKey = counter ? `${key}${separator}${counter}` : key
+  return test(testKey) ? testKey : incrementKeyUntilUnique(key, counter + 1, test, separator)
 }
 
 module.exports = {


### PR DESCRIPTION
Previously, collapsedLayoutNode ids were based on concatenations of the IDs of the nodes they contain, and look like this:

```
clump:C19,C20,C21,C22,C23,C24
clump:A10,A11,A12,A13,A14,A15,A16,A17,A18,A19,A20,A21
clump:A16,A19
```
The hashes used to expose the currently selected node, if a collapsed node is selected, are based on chains telling Bubbleprof what jumps to make to find a particular node (because collapsedLayoutNodes are only created during the sublayout creation process). Previously, they looked like this:

```
15896.clinic-bubbleprof.html#lclump:C19,C20,C21,C22,C23,C24|m
15896.clinic-bubbleprof.html#lclump:A16,A19|lclump:A10,A11,A12,A13,A14,A15,A16,A17,A18,A19,A20,A21|c3
```

Or to give an extreme example:

```
7078.clinic-bubbleprof.html#lclump:A71,A79,A80,A85,A92,A93,A98,A103,A104,A106,A109,A110,A112,A113,A114,A115,A116,A117,A118,A119,A120,A121,A122,A123,A124,A125,A126,A127,A128,A129,A130,A131,A132,A133,A134,A135,A136,A137,A138,A139,A140,A141,A142,A143,A144,A145,A146,A147,A148,A149,A150,A151,A152,A153,A154,A155,A156,A157,A158,A159,A160,A161,A162,A163,A164,A165,A166,A167,A168,A169,A170,A171,A172,A173,A174,A175,A176,A177,A178,A179,A180,A181,A182,A183,A184,A185,A186,A187,A188,A189,A190,A191,A192,A193,A194,A195,A196,A197,A198,A199,A200,A201,A202,A203,A204,A205,A206,A207,A208,A209,A210,A211,A212,A213,A214,A215,A216,A217,A218,A219,A220,A221,A222,A223,A224,A225,A226,A227,A228,A229,A230,A231,A232,A233,A234,A235,A236,A237,A238,A239,A240,A241,A242,A243,A244,A245,A246,A247,A248,A249,A250,A251,A252,A253|lclump:A55,A56,A71,A79,A80,A85,A92,A93,A98,A103,A104,A106,A109,A110,A112,A113,A114,A115,A116,A117,A118,A119,A120,A121,A122,A123,A124,A125,A126,A127,A128,A129,A130,A131,A132,A133,A134,A135,A136,A137,A138,A139,A140,A141,A142,A143,A144,A145,A146,A147,A148,A149,A150,A151,A152,A153,A154,A155,A156,A157,A158,A159,A160,A161,A162,A163,A164,A165,A166,A167,A168,A169,A170,A171,A172,A173,A174,A175,A176,A177,A178,A179,A180,A181,A182,A183,A184,A185,A186,A187,A188,A189,A190,A191,A192,A193,A194,A195,A196,A197,A198,A199,A200,A201,A202,A203,A204,A205,A206,A207,A208,A209,A210,A211,A212,A213,A214,A215,A216,A217,A218,A219,A220,A221,A222,A223,A224,A225,A226,A227,A228,A229,A230,A231,A232,A233,A234,A235,A236,A237,A238,A239,A240,A241,A242,A243,A244,A245,A246,A247,A248,A249,A250,A251,A252,A253|lclump:A34,A55,A56,A71,A79,A80,A85,A92,A93,A98,A103,A104,A106,A109,A110,A112,A113,A114,A115,A116,A117,A118,A119,A120,A121,A122,A123,A124,A125,A126,A127,A128,A129,A130,A131,A132,A133,A134,A135,A136,A137,A138,A139,A140,A141,A142,A143,A144,A145,A146,A147,A148,A149,A150,A151,A152,A153,A154,A155,A156,A157,A158,A159,A160,A161,A162,A163,A164,A165,A166,A167,A168,A169,A170,A171,A172,A173,A174,A175,A176,A177,A178,A179,A180,A181,A182,A183,A184,A185,A186,A187,A188,A189,A190,A191,A192,A193,A194,A195,A196,A197,A198,A199,A200,A201,A202,A203,A204,A205,A206,A207,A208,A209,A210,A211,A212,A213,A214,A215,A216,A217,A218,A219,A220,A221,A222,A223,A224,A225,A226,A227,A228,A229,A230,A231,A232,A233,A234,A235,A236,A237,A238,A239,A240,A241,A242,A243,A244,A245,A246,A247,A248,A249,A250,A251,A252,A253|lclump:A21,A22,A34,A55,A56,A71,A79,A80,A85,A92,A93,A98,A103,A104,A106,A109,A110,A112,A113,A114,A115,A116,A117,A118,A119,A120,A121,A122,A123,A124,A125,A126,A127,A128,A129,A130,A131,A132,A133,A134,A135,A136,A137,A138,A139,A140,A141,A142,A143,A144,A145,A146,A147,A148,A149,A150,A151,A152,A153,A154,A155,A156,A157,A158,A159,A160,A161,A162,A163,A164,A165,A166,A167,A168,A169,A170,A171,A172,A173,A174,A175,A176,A177,A178,A179,A180,A181,A182,A183,A184,A185,A186,A187,A188,A189,A190,A191,A192,A193,A194,A195,A196,A197,A198,A199,A200,A201,A202,A203,A204,A205,A206,A207,A208,A209,A210,A211,A212,A213,A214,A215,A216,A217,A218,A219,A220,A221,A222,A223,A224,A225,A226,A227,A228,A229,A230,A231,A232,A233,A234,A235,A236,A237,A238,A239,A240,A241,A242,A243,A244,A245,A246,A247,A248,A249,A250,A251,A252,A253|lclump:A15,A21,A22,A34,A55,A56,A71,A79,A80,A85,A92,A93,A98,A103,A104,A106,A109,A110,A112,A113,A114,A115,A116,A117,A118,A119,A120,A121,A122,A123,A124,A125,A126,A127,A128,A129,A130,A131,A132,A133,A134,A135,A136,A137,A138,A139,A140,A141,A142,A143,A144,A145,A146,A147,A148,A149,A150,A151,A152,A153,A154,A155,A156,A157,A158,A159,A160,A161,A162,A163,A164,A165,A166,A167,A168,A169,A170,A171,A172,A173,A174,A175,A176,A177,A178,A179,A180,A181,A182,A183,A184,A185,A186,A187,A188,A189,A190,A191,A192,A193,A194,A195,A196,A197,A198,A199,A200,A201,A202,A203,A204,A205,A206,A207,A208,A209,A210,A211,A212,A213,A214,A215,A216,A217,A218,A219,A220,A221,A222,A223,A224,A225,A226,A227,A228,A229,A230,A231,A232,A233,A234,A235,A236,A237,A238,A239,A240,A241,A242,A243,A244,A245,A246,A247,A248,A249,A250,A251,A252,A253|c5
```

These aren't robust against URL encoding, which means if a link to one is posted on a site that automatically URL-encodes, the hash link will break. 

It's also pretty ugly. [Hashes can be up to 50k characters long, or  ~2,000 on MS browsers](https://stackoverflow.com/questions/16247162/max-size-of-location-hash-in-browser), but that doesn't mean they _should_ be...

This PR changes the IDs to be like ~~`x`, `x1`, `x2`~~ `x1`, `x2`, `x3`, unique to their layout (no need to be unique between layouts because by definition they're unique to the layout they were collapsed inside, so it makes no sense to access them without this context).

In this PR's new approach the above hash URLs become:

```
15896.clinic-bubbleprof.html#x5
15896.clinic-bubbleprof.html#x1-x1-c3
```

And that extreme example becomes:

```
7078.clinic-bubbleprof.html#x1-x2-x1-x2-x1-c5
```

URL-encoding-safe (and much less ugly).

Some of the tests updated in this PR used the IDs as a way to check that the node IDs in a layout and in a collapsed node were as expected - these have been updated with explicit tests testing those things separately.