### PR TITLE
Give collapsedNodes names by interestingness

### DIFF
--- a/visualizer/data/data-node.js
+++ b/visualizer/data/data-node.js
@@ -46,6 +46,7 @@ class DataNode {
   getBetweenTime () { return this.stats.async.between }
   getAsyncTime () { return this.stats.async.between + this.stats.async.within }
   getSyncTime () { return this.stats.sync }
+  getTotalTime () { return this.stats.overall }
 
   getParentNode () {
     return this.dataSet.getByNodeType(this.constructor.name, this.parentId)

--- a/visualizer/data/data-node.js
+++ b/visualizer/data/data-node.js
@@ -380,9 +380,6 @@ class ArtificialNode extends ClusterNode {
       if (!this.mark) this.mark = aggregateNode.mark
     }
   }
-  applyMark (mark) {
-    if (!this.mark) this.mark = mark
-  }
   getSameType (nodeId) {
     return this.dataSet.getByNodeType(this.nodeType, nodeId)
   }

--- a/visualizer/layout/layout-node.js
+++ b/visualizer/layout/layout-node.js
@@ -141,7 +141,8 @@ function sortNodesByLargestTime (a, b) {
 }
 function truncateName (name) {
   const splitName = name.split(/(?=[+&>])/)
-  const newName = splitName[0].trim()
+  let newName = splitName[0].trim()
+  if (newName === '...') newName = splitName[1].slice(1).trim()
   return splitName.length > 1 ? newName + '…' : newName
 }
 

--- a/visualizer/layout/layout-node.js
+++ b/visualizer/layout/layout-node.js
@@ -142,14 +142,16 @@ function truncateName (name, fullName) {
   for (let i = 0; i < splitNameLength; i++) {
     const subName = trimName(splitName[i])
 
-    // Some names are like `... > someModule > anotherModule`
+    // Some names are like `... > someModule > anotherModule` from analysis branch
+    // - Filter out '...' from analysis for main diagram (show in hover only).
+    // - Add '…' to indicate contraction in draw branch, and don't filter it out.
     if ((subName) === '...') continue
 
-    const prefix = i === 0 ? '' : '...'
-    const suffix = i === splitNameLength - 1 ? '' : '...'
+    const prefix = i === 0 ? '' : '…'
+    const suffix = i === splitNameLength - 1 ? '' : '…'
     if (!fullName.includes(subName)) return `${prefix}${subName}${suffix}`
   }
-  return trimName(splitName[0]) + '...'
+  return trimName(splitName[0]) + '…'
 }
 
 function trimName (name) {

--- a/visualizer/layout/layout-node.js
+++ b/visualizer/layout/layout-node.js
@@ -55,7 +55,6 @@ class CollapsedLayoutNode {
         }, node, dataNodes)
       }
       if (node.nodes) this.node.applyAggregateNodes(node.nodes)
-      this.node.applyMark(node.mark)
       this.node.aggregateStats(node)
       this.applyDecimals(node)
       const party = node.mark.get('party')
@@ -63,6 +62,7 @@ class CollapsedLayoutNode {
     }
     const nodesByPriority = this.getNodesByPriority(nodesByParty, dataNodes)
     this.node.name = this.getCollapsedName(nodesByPriority)
+    this.node.mark = nodesByPriority[0].mark
   }
   getNodesByPriority (nodesByParty, dataNodes) {
     // Get the two most 'interesting' names from the collapsed set

--- a/visualizer/layout/layout-node.js
+++ b/visualizer/layout/layout-node.js
@@ -61,10 +61,10 @@ class CollapsedLayoutNode {
       const party = node.mark.get('party')
       nodesByParty[party === 'root' ? 'nodecore' : party].push(node)
     }
-
-    this.node.name = this.getCollapsedName(nodesByParty, dataNodes)
+    const nodesByPriority = this.getNodesByPriority(nodesByParty, dataNodes)
+    this.node.name = this.getCollapsedName(nodesByPriority)
   }
-  getCollapsedName (nodesByParty, dataNodes) {
+  getNodesByPriority (nodesByParty, dataNodes) {
     // Get the two most 'interesting' names from the collapsed set
     // Prioritise userland > external > nodecore, and boost relatively large nodes
     nodesByParty.user.sort(sortNodesByLargestTime)
@@ -98,14 +98,16 @@ class CollapsedLayoutNode {
       dedupe[node.id] = true
       return true
     })
-
+    return nodesByPriority
+  }
+  getCollapsedName (nodesByPriority) {
     let name = `${truncateName(nodesByPriority[0].name)}`
     let index = 1
     while (name.length < 24 && nodesByPriority[index]) {
       name += ` & ${truncateName(nodesByPriority[index].name)}`
       index++
     }
-    return dataNodes.length > index ? name + ' & …' : name
+    return nodesByPriority.length > index ? name + ' & …' : name
   }
   getBetweenTime () {
     return this.collapsedNodes.reduce((total, layoutNode) => total + layoutNode.node.getBetweenTime(), 0)

--- a/visualizer/layout/layout-node.js
+++ b/visualizer/layout/layout-node.js
@@ -30,7 +30,7 @@ class LayoutNode {
 class CollapsedLayoutNode {
   constructor (collapsedId, layoutNodes, parent, children) {
     // layoutNodes should be an array sorted using layout.getLayoutNodeSorter()
-    const dataNodes = layoutNodes.map(layoutNode => layoutNode.node)
+    const dataNodes = layoutNodes.map(layoutNode => layoutNode.node).sort(sortNodesByLargestTime)
 
     // Collapsed ids are for uniqueness and human inspection; sort ids into a human-readable order
     this.id = collapsedId
@@ -38,6 +38,12 @@ class CollapsedLayoutNode {
     this.collapsedNodes = layoutNodes
     this.parent = parent
     this.children = children || []
+
+    const nodesByParty = {
+      user: [],
+      external: [],
+      nodecore: []
+    }
 
     for (let i = 0; i < layoutNodes.length; ++i) {
       const layoutNode = layoutNodes[i]
@@ -52,7 +58,54 @@ class CollapsedLayoutNode {
       this.node.applyMark(node.mark)
       this.node.aggregateStats(node)
       this.applyDecimals(node)
+      const party = node.mark.get('party')
+      nodesByParty[party === 'root' ? 'nodecore' : party].push(node)
     }
+
+    this.node.name = this.getCollapsedName(nodesByParty, dataNodes)
+  }
+  getCollapsedName (nodesByParty, dataNodes) {
+    // Get the two most 'interesting' names from the collapsed set
+    // Prioritise userland > external > nodecore, and boost relatively large nodes
+    nodesByParty.user.sort(sortNodesByLargestTime)
+    nodesByParty.external.sort(sortNodesByLargestTime)
+    nodesByParty.nodecore.sort(sortNodesByLargestTime)
+
+    const overallTime = this.getTotalTime()
+
+    const node0 = dataNodes[0]
+    const node0Time = node0.getTotalTime() / overallTime
+    const node0Party = node0.mark.get('party')
+
+    const dedupe = {}
+
+    const nodesByPriority = [
+      // Very large external or nodecore names push ahead of top userland (or external)
+      node0Time >= 0.5 && node0Party === 'external' ? node0 : null,
+      node0Time >= 0.6 && node0Party === 'nodecore' ? node0 : null,
+      nodesByParty.user[0],
+      nodesByParty.external[0],
+      nodesByParty.nodecore[0],
+      // Large external or nodecore names push out 2nd userland or external
+      node0Time > 0.25 && node0Time < 0.5 && node0Party === 'external' ? node0 : null,
+      node0Time > 0.3 && node0Time < 0.6 && node0Party === 'nodecore' ? node0 : null,
+      nodesByParty.user[1],
+      nodesByParty.external[1],
+      nodesByParty.nodecore[1]
+    ].filter(node => {
+      // remove undefined and duplicates
+      if (!node || dedupe[node.id]) return false
+      dedupe[node.id] = true
+      return true
+    })
+
+    let name = `${truncateName(nodesByPriority[0].name)}`
+    let index = 1
+    while (name.length < 24 && nodesByPriority[index]) {
+      name += ` & ${truncateName(nodesByPriority[index].name)}`
+      index++
+    }
+    return dataNodes.length > index ? name + ' & …' : name
   }
   getBetweenTime () {
     return this.collapsedNodes.reduce((total, layoutNode) => total + layoutNode.node.getBetweenTime(), 0)
@@ -81,6 +134,15 @@ class CollapsedLayoutNode {
     this.node.aggregateDecimals(otherNode, 'party', 'between')
     this.node.aggregateDecimals(otherNode, 'party', 'within')
   }
+}
+
+function sortNodesByLargestTime (a, b) {
+  return b.getTotalTime() - a.getTotalTime()
+}
+function truncateName (name) {
+  const splitName = name.split(/(?=[+&>])/)
+  const newName = splitName[0].trim()
+  return splitName.length > 1 ? newName + '…' : newName
 }
 
 module.exports = {


### PR DESCRIPTION
Not ready to merge yet, needs some tests - but first it needs some human testing to make sure it is actually giving names which reflect what is interesting inside a collapsed node.

So please try this out and dig around looking for cases where what you get when you click into a collapsed node is not what you might have expected from its name.

(tip: it's now possible to tell by looking if something is a collapsed node or not, they use `&` as a seperator while clusterNodes use `+`. This isn't something we'd necessarily expect or want users to notice, but it can be useful for debugging or advanced users maybe)