### PR TITLE
Upgrade appveyor to use Node 10 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@
 version: "{build}"
 
 environment:
-  nodejs_version: 9
+  nodejs_version: 10
 
 # fix line endings in Windows
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,9 @@
 version: "{build}"
 
 environment:
-  nodejs_version: 10
+  matrix:
+    - nodejs_version: "8"
+    - nodejs_version: "10"
 
 # fix line endings in Windows
 init:
@@ -13,14 +15,13 @@ init:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - node -v
+  - npm -v
   - npm config set package-lock false
   - npm update --save-dev # https://github.com/npm/npm/issues/16901
   - npm update
 
 build: off
-
-cache:
-  - node_modules -> package.json
 
 configuration: build-lint-test
 

--- a/test/integration-servers.test.js
+++ b/test/integration-servers.test.js
@@ -55,7 +55,7 @@ test('latency server has http.connection.end cluster', function (t) {
   runServer('latency', function (err, nodes) {
     if (err) return t.ifError(err)
 
-    const endName = nodes.some(c => c.name === 'http.connection.end')
+    const endName = nodes.some(c => c.name.includes('http.connection.end'))
     t.ok(endName, 'has http.connection.end name')
     t.end()
   })


### PR DESCRIPTION
Reason for `Windows fix`:

Unix
<img width="175" alt="screen shot 2018-07-31 at 16 55 51" src="https://user-images.githubusercontent.com/10513845/43471698-84c405cc-94e3-11e8-9c1d-321256ba7aa2.png">

Windows
![unnamed](https://user-images.githubusercontent.com/10513845/43471707-8a3a9f20-94e3-11e8-9d01-0fdf606eb400.png)
