### PR TITLE
Fix extremely large sublayouts (1,000+ nodes, chains 100+ long)

### DIFF
--- a/test/visualizer-layout-layer.test.js
+++ b/test/visualizer-layout-layer.test.js
@@ -14,6 +14,11 @@ const layoutSettings = {
   lineWidth: 2.5,
   labelMinimumSpace: 14
 }
+const stretchableSettings = Object.assign({}, layoutSettings, {
+  allowStretch: true
+})
+// absolute gaps between nodes, in px
+const lineExtras = (layoutSettings.lineWidth + layoutSettings.labelMinimumSpace * 2)
 
 test('Visualizer - layer - dataset is healthy', function (t) {
   const dataSet = new DataSet({data: clusterNodesArray})
@@ -51,7 +56,7 @@ test('Visualizer - layer - layout is healthy on init', function (t) {
   // Ensure custom settings get applied over defaults as expected
   t.deepEqual(layout.settings, Object.assign({}, layout.settings, layoutSettings))
 
-  t.equal(layout.layoutNodes.get('A').parent, undefined)
+  t.equal(layout.layoutNodes.get('A').parent, null)
   t.deepEqual(layout.layoutNodes.get('A').children, ['B', 'C'])
   t.equal(layout.layoutNodes.get('B').parent.id, layout.layoutNodes.get('A').id)
   t.equal(layout.layoutNodes.get('C').parent.id, layout.layoutNodes.get('A').id)
@@ -72,7 +77,6 @@ test('Visualizer - layer - layout stems are healthy on processBetweenData', func
   dataSet.processData()
   const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, layoutSettings)
 
-  const lineExtras = (2.5 + 14 + 14)
   const expected = {
     A: {},
     B: {},
@@ -237,12 +241,11 @@ test('Visualizer - layer - layout connections are healthy on processBetweenData'
 test('Visualizer - layer - layout scale is healthy on calculateScaleFactor', function (t) {
   const dataSet = new DataSet({data: clusterNodesArray})
   dataSet.processData()
-  const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, layoutSettings)
+  const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, stretchableSettings)
 
   layout.processBetweenData()
   layout.updateScale()
 
-  const lineExtras = (2.5 + 14 + 14)
   const expectedScaleFactor = 25.7102
 
   t.deepEqual(layout.scale.scalesBySmallest.map(weight => [weight.category, weight.weight.toFixed(4)]), [
@@ -271,7 +274,7 @@ test('Visualizer - layer - layout scale is healthy on calculateScaleFactor', fun
 test('Visualizer - layer - layout stems are healthy on calculateScaleFactor', function (t) {
   const dataSet = new DataSet({data: clusterNodesArray})
   dataSet.processData()
-  const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, layoutSettings)
+  const layout = new Layout({ dataNodes: [...dataSet.clusterNodes.values()] }, stretchableSettings)
 
   layout.processBetweenData()
   layout.updateScale()
@@ -280,7 +283,6 @@ test('Visualizer - layer - layout stems are healthy on calculateScaleFactor', fu
   t.equal(layout.scale.prescaleFactor, layout.settings.svgHeight / APlusBPlusD)
   t.ok(layout.scale.prescaleFactor < 58 && layout.scale.prescaleFactor > 57)
 
-  const lineExtras = (2.5 + 14 + 14)
   const expectedScaleFactor = 25.7102
 
   t.equal(layout.layoutNodes.get('A').stem.scaled.ownBetween, lineExtras)

--- a/test/visualizer-layout-scale.test.js
+++ b/test/visualizer-layout-scale.test.js
@@ -312,3 +312,43 @@ test('Visualizer layout - scale - can handle zero-sized views', function (t) {
 
   t.end()
 })
+
+settings.allowStretch = false
+settings.labelMinimumSpace = 10
+settings.lineWidth = 10
+
+test('Visualizer layout - scale - calculation height always greater thans longest stem', function (t) {
+  function testLongNodeChains (topology) {
+    const dataSet = loadData(dataSettings, mockTopology(topology))
+    const layout = generateLayout(dataSet, settings)
+    layout.updateScale()
+
+    const largestSize = layout.scale.decisiveWeight.absoluteToContain + layout.scale.decisiveWeight.scalableToContain * layout.scale.scaleFactor
+    t.ok(layout.scale.finalSvgHeight > largestSize)
+  }
+
+  testLongNodeChains([
+    ['1.2', 100],
+    // Long chain of nodes: 1.3.4.5.6.7.8...2998.2999.3000
+    ['1.3.' + Array(2997).fill(4).map((num, index) => num + index).join('.'), 5]
+  ])
+
+  testLongNodeChains([
+    ['1.2', 100],
+    ['1.3.' + Array(397).fill(4).map((num, index) => num + index).join('.'), 5],
+    ['1.401.' + Array(399).fill(402).map((num, index) => num + index).join('.'), 5],
+    ['1.801.' + Array(399).fill(802).map((num, index) => num + index).join('.'), 5],
+    ['1.1201.' + Array(399).fill(1202).map((num, index) => num + index).join('.'), 5],
+    ['1.1601.' + Array(399).fill(1602).map((num, index) => num + index).join('.'), 5]
+  ])
+
+  /* TODO - fix error where this fails with error from arrayFlatten recursion being too deep
+  // Very slow test - keep it commented out and uncomment as a smoke test for very large profile issues
+  testLongNodeChains([
+    ['1.2', 100],
+    ['1.3.' + Array(9997).fill(4).map((num, index) => num + index).join('.'), 5]
+  ])
+  */
+
+  t.end()
+})

--- a/visualizer/layout/collapsed-layout.js
+++ b/visualizer/layout/collapsed-layout.js
@@ -18,6 +18,8 @@ class CollapsedLayout {
     this.scale = layout.scale
     this.minimumNodes = 3
 
+    this.collapseThreshold = 10 * this.scale.heightMultiplier
+
     // If debugging, expose one pool of ejected node IDs that is added to each time this class is initialized
     if (layout.settings.debugMode && !layout.ejectedLayoutNodeIds) layout.ejectedLayoutNodeIds = []
 
@@ -197,7 +199,7 @@ class CollapsedLayout {
     return collapsed
   }
   isBelowThreshold (layoutNode) {
-    return layoutNode.getTotalTime() * this.scale.sizeIndependentScale < 10
+    return layoutNode.getTotalTime() * this.scale.sizeIndependentScale < this.collapseThreshold
   }
   isCollapsible (layoutNode) {
     return layoutNode.collapsedNodes || this.isBelowThreshold(layoutNode)

--- a/visualizer/layout/layout.js
+++ b/visualizer/layout/layout.js
@@ -188,7 +188,7 @@ class Layout {
   }
 
   updateScale (collapsed = false) {
-    this.scale.calculatePreScaleFactor()
+    this.scale.calculatePreScaleFactor(collapsed)
     this.updateStems()
     this.scale.calculateScaleFactor(collapsed)
     this.updateStems()

--- a/visualizer/layout/layout.js
+++ b/visualizer/layout/layout.js
@@ -50,25 +50,38 @@ class Layout {
     this.layoutNodes = new Map()
 
     const dataNodeById = new Map(dataNodes.map(node => [node.id, node]))
-    const createLayoutNode = (nodeId, parentLayoutNode) => {
-      const dataNode = dataNodeById.get(nodeId)
-      if (!dataNode || this.layoutNodes.has(dataNode.id)) return
 
-      const layoutNode = new LayoutNode(dataNode, parentLayoutNode)
-      this.layoutNodes.set(dataNode.id, layoutNode)
-
-      if (dataNode.isRoot) this.rootLayoutNode = this.layoutNodes.get(dataNode.id)
-
-      if (parentLayoutNode) parentLayoutNode.children.push(dataNode.id)
-      for (let i = 0; i < dataNode.children.length; ++i) {
-        const childNodeId = dataNode.children[i]
-        createLayoutNode(childNodeId, layoutNode)
+    const nodesByTreeOrder = dataNodes.filter(dataNode => !dataNode.parent).map(dataNode => {
+      return {
+        id: dataNode.id,
+        parent: null
       }
-    }
-    const topDataNodes = dataNodes.filter(dataNode => !dataNode.parent)
-    for (let i = 0; i < topDataNodes.length; ++i) {
-      const topDataNode = topDataNodes[i]
-      createLayoutNode(topDataNode.id)
+    })
+
+    // Traverse through the tree depth-first, without recursion because depths (initial chain lengths) are unbounded.
+    // For example, cluster nodes could contain aggregate node chains of any length before collapse logic applies.
+    while (nodesByTreeOrder.length) {
+      const {
+        id,
+        parent
+      } = nodesByTreeOrder.shift()
+
+      const dataNode = dataNodeById.get(id)
+      if (!dataNode || this.layoutNodes.has(id)) continue
+
+      const layoutNode = new LayoutNode(dataNode, parent)
+      this.layoutNodes.set(id, layoutNode)
+
+      if (dataNode.isRoot) this.rootLayoutNode = this.layoutNodes.get(id)
+      if (parent) parent.children.push(id)
+
+      // First children and their descendents first (iterate children backwards, queue each next in array)
+      for (let i = dataNode.children.length; i >= 0; i--) {
+        nodesByTreeOrder.unshift({
+          id: dataNode.children[i],
+          parent: layoutNode
+        })
+      }
     }
   }
 

--- a/visualizer/layout/layout.js
+++ b/visualizer/layout/layout.js
@@ -192,6 +192,8 @@ class Layout {
     this.updateStems()
     this.scale.calculateScaleFactor(collapsed)
     this.updateStems()
+    const wasAdjusted = this.scale.adjustScaleFactor(collapsed)
+    if (wasAdjusted) this.updateStems()
   }
 
   updateStems () {

--- a/visualizer/layout/layout.js
+++ b/visualizer/layout/layout.js
@@ -183,14 +183,14 @@ class Layout {
     if (settings.collapseNodes) {
       this.collapseNodes()
       this.processBetweenData(true)
-      this.updateScale()
+      this.updateScale(true)
     }
   }
 
-  updateScale () {
+  updateScale (collapsed = false) {
     this.scale.calculatePreScaleFactor()
     this.updateStems()
-    this.scale.calculateScaleFactor()
+    this.scale.calculateScaleFactor(collapsed)
     this.updateStems()
   }
 

--- a/visualizer/layout/scale.js
+++ b/visualizer/layout/scale.js
@@ -15,17 +15,20 @@ class Scale {
   calculatePreScaleFactor () {
     this.layoutNodes = this.layout.layoutNodes
 
+    // Setting used in tests and for (legacy) scrollable fixed height layouts
+    const isStretchMode = this.layout.settings.allowStretch
+
     // Calculate the total fixed (absolute) pixel length gaps in the longest stem. For example, if a view initially
     // contains 1000 nodes and each node has a fixed gap of 10px, that's 10,000px we need to account for
     const toLongestAbsolute = (longest, layoutNode) => Math.max(longest, layoutNode.stem.lengths.absolute)
-    const longestAbsolute = [...this.layoutNodes.values()].reduce(toLongestAbsolute, 0)
+    const longestAbsolute = isStretchMode ? 0 : [...this.layoutNodes.values()].reduce(toLongestAbsolute, 0)
 
     // Extend the effective heights, lengths and thresholds used in calculations by that amount
     this.heightMultiplier = 1 + (longestAbsolute / this.layout.settings.svgHeight)
     const toLongest = (longest, layoutNode) => Math.max(longest, layoutNode.stem.lengths.scalable)
     const longest = [...this.layoutNodes.values()].reduce(toLongest, 0) + longestAbsolute
 
-    const scaleByHeight = this.layout.settings.svgHeight * this.heightMultiplier
+    const scaleByHeight = this.layout.settings.svgHeight * (isStretchMode ? 1 : this.heightMultiplier)
     this.prescaleFactor = scaleByHeight / (longest || 1)
   }
   calculateScaleFactor (collapsed = false) {

--- a/visualizer/layout/stems.js
+++ b/visualizer/layout/stems.js
@@ -62,10 +62,10 @@ class Stem {
         rawTotal: absolute + scalable
       }
     }
-    if (this.layout.scale.prescaleFactor) {
+    if (typeof this.layout.scale.prescaleFactor === 'number') {
       this.lengths.prescaledTotal = this.lengths.absolute + (this.lengths.scalable * this.layout.scale.prescaleFactor)
     }
-    if (this.layout.scale.scaleFactor) {
+    if (typeof this.layout.scale.scaleFactor === 'number') {
       const { settings, scale } = this.layout
       this.scaled = {
         ownBetween: (settings.labelMinimumSpace * 2) + settings.lineWidth + scale.getLineLength(this.raw.ownBetween),


### PR DESCRIPTION
Fixes a rare but serious bug creating broken layouts on clicking into clusterNodes with very many aggregateNodes.

On digging into this I found it seems to happen when the total of the (unscalable) gaps between nodes exceeds the space available.

Here are a couple of 'before' examples:

https://upload.clinicjs.org/public/1e48153768a19dcf5bac7c225571945beb1fa282f022a767e135386ba14eb96c/1005.clinic-bubbleprof.html#c3 - 5,068 aggregate nodes in one cluster node

![image](https://user-images.githubusercontent.com/29628323/43535977-50c04152-95b3-11e8-8072-f5888dc63f34.png)

https://upload.clinicjs.org/public/39a458eeb928801e0cb2ad69cfb2108358fa3c72be6ac44a4e9b6ff9d413827d/21608.clinic-bubbleprof.html#c14 - 1,115 aggregate nodes in one cluster node

![image](https://user-images.githubusercontent.com/29628323/43535952-3f7021e2-95b3-11e8-9422-8642cd16b244.png)

This PR fixes this by taking the total length of these unscalable gaps in the longest chain in the layout and adding it to the height of the space which is used when calculating the first, pre-collapse layout, as well as applying the % increase in total height to the collapsing threshold. Then, after collapsing small nodes together, we can use the correct height because the sublayout will have been collapsed down to a reason number of nodes.

Those same profiles generated with this PR:

https://upload.clinicjs.org/public/81bd1274028e32b2e257edd921245f0d989587c3c93cf45ad60602087d896559/1005.clinic-bubbleprof.html#c3

![image](https://user-images.githubusercontent.com/29628323/43535730-a9a16752-95b2-11e8-9a0f-42d042e273a0.png)

https://upload.clinicjs.org/public/487567a841d65c480d0f10d37d33e0ac91abf864cb225cacaa221101ad331ee1/21608.clinic-bubbleprof.html#c14

![image](https://user-images.githubusercontent.com/29628323/43535788-c82ff47c-95b2-11e8-828f-dec073817f3c.png)