### PR TITLE
Keep previous value of combined layoutNode if combineLayoutNodes cancels

### DIFF
--- a/visualizer/layout/collapsed-layout.js
+++ b/visualizer/layout/collapsed-layout.js
@@ -128,7 +128,7 @@ class CollapsedLayout {
       }
       if (belowThreshold) {
         if (combined || prevTiny) {
-          combined = this.combinelayoutNodes(combined || prevTiny, child)
+          combined = this.combineLayoutNodes(combined || prevTiny, child)
         }
         prevTiny = child
       }
@@ -152,12 +152,12 @@ class CollapsedLayout {
         if (longGrandChild) {
           continue
         }
-        combined = this.combinelayoutNodes(hostNode, squashNode)
+        combined = this.combineLayoutNodes(hostNode, squashNode)
       }
     }
     return combined
   }
-  combinelayoutNodes (hostNode, squashNode) {
+  combineLayoutNodes (hostNode, squashNode) {
     if ([hostNode.node.constructor.name, squashNode.node.constructor.name].includes('ShortcutNode')) {
       return
     }

--- a/visualizer/layout/collapsed-layout.js
+++ b/visualizer/layout/collapsed-layout.js
@@ -152,7 +152,8 @@ class CollapsedLayout {
         if (longGrandChild) {
           continue
         }
-        combined = this.combineLayoutNodes(hostNode, squashNode)
+        // combineLayoutNodes() can cancel itself and return nothing; if so, keep previous value of combined
+        combined = this.combineLayoutNodes(hostNode, squashNode) || combined
       }
     }
     return combined


### PR DESCRIPTION
A very rare bug, but a serious one which causes an error and stops a layout from loading.

This happens if:

- a node is collapsed while collapseVertically is iterating through its children, 
- then, one of those children meets the criteria whereby the `combineLayoutNodes` method cancels itself, 
- then, another of its children attempts to collapse into the same group. 

When the method cancelled itself, it did so with `return`, removing the collapsed node from the loop. It then tries to collapse the next collapsible child into a node that was already ejected, hitting an error like:

```
Cannot combine nodes - clump/stem mismatch
```

This PR keeps the previous value of `combine` if `combineLayoutNodes` returns a falsey value (if it doesn't cancel, it returns a collapsedLayoutNode object).

It's a very difficult bug to replicate because the conditions are so specific... The only place it's ever been seen to date is in one specific view four layers deep in a WIP bug fix branch on the crazy Apostrophe profile with 5,000+ aggregate nodes inside one  cluster node. 

But it could theoretically turn up anywhere. 

Here's a 'before' sample (note - this is the profile which is affected by a known performance slowdown described elsewhere and on the to-fix list):

https://upload.clinicjs.org/public/227bbbc2e71993bb484c36bc2a4f7df957b528e76885010fb611a6ec80bdb683/1005.clinic-bubbleprof.html#x2385-x4992-c3

...and here's an after:

https://upload.clinicjs.org/public/0db071669f1c0f7256fde9fd42571ab57bd684444de295415c90d254f6425bb1/1005.clinic-bubbleprof.html#x2385-x4992-c3

(this 'after' also reveals yet another extremely rare bug... this one much simpler and less serious: that having a collapse limit of 3 means you can have a layout with a backwards arrow, a forwards arrow, and a collapsedNode that contains everything that takes you to an exact copy of this view when you click on it... This one just requires raising the collapse limit, or not counting shortcut nodes in the collapse limit).