### PR TITLE
Don't count shortcutNodes when checking minimumNodes

### DIFF
--- a/visualizer/layout/collapsed-layout.js
+++ b/visualizer/layout/collapsed-layout.js
@@ -123,7 +123,7 @@ class CollapsedLayout {
       const child = children[i]
       const belowThreshold = this.isBelowThreshold(child)
       this.collapseHorizontally(child)
-      if (this.layoutNodes.size === this.minimumNodes) {
+      if (this.countNonShortcutNodes() <= this.minimumNodes) {
         break
       }
       if (belowThreshold) {
@@ -141,7 +141,7 @@ class CollapsedLayout {
       const child = children[i]
       const belowThreshold = child.collapsedNodes || this.isBelowThreshold(child)
       const collapsedChild = this.collapseVertically(child)
-      if (this.layoutNodes.size === this.minimumNodes) {
+      if (this.countNonShortcutNodes() <= this.minimumNodes) {
         break
       }
       if (belowThreshold && !this.topLayoutNodes.has(layoutNode)) {
@@ -197,6 +197,13 @@ class CollapsedLayout {
     this.layoutNodes.delete(squashNode.id)
 
     return collapsed
+  }
+  countNonShortcutNodes () {
+    let shortcutCount = 0
+    this.layoutNodes.forEach(layoutNode => {
+      if (layoutNode.node.constructor.name === 'ShortcutNode') shortcutCount++
+    })
+    return this.layoutNodes.size - shortcutCount
   }
   isBelowThreshold (layoutNode) {
     return layoutNode.getTotalTime() * this.scale.sizeIndependentScale < this.collapseThreshold


### PR DESCRIPTION
A basic fix for an issue mentioned in https://github.com/nearform/node-clinic-bubbleprof/pull/237

We have limit on node collapsing of 3 intended to stop views where everything is collapsed, where you click into the one big node and get the same identical view where everything is collapsed. However, it counts uncollapsible shortcutNodes (arrows), which means you can get the endless collapse everything problem if the view contains two or more shortcuts

https://upload.clinicjs.org/public/0db071669f1c0f7256fde9fd42571ab57bd684444de295415c90d254f6425bb1/1005.clinic-bubbleprof.html#x2385-x4992-c3

![image](https://user-images.githubusercontent.com/29628323/43777083-aeb4bb04-9a49-11e8-95f5-a53842cd9d95.png)

This PR only counts non-shortcuts when checking if the minimumNodes limit has been reached. We could still do with a smarter collapse limit, but this prevents impossible-to-enter views and infinite loops if jumpToNode is used.

![image](https://user-images.githubusercontent.com/29628323/43777021-86074f32-9a49-11e8-8e9b-44aff2a78011.png)

https://upload.clinicjs.org/public/78721c7e34917bc49379b6219e72409ff993b27d8540bb2e53ef86870d545d53/1005.clinic-bubbleprof.html#x2385-x4992-c3