### PR TITLE
Adjust collapse threshold to ensure that the layout can fit in a reasonable window

### DIFF
--- a/test/visualizer-layout-scale.test.js
+++ b/test/visualizer-layout-scale.test.js
@@ -325,6 +325,7 @@ test('Visualizer layout - scale - calculation height always greater thans longes
 
     const largestSize = layout.scale.decisiveWeight.absoluteToContain + layout.scale.decisiveWeight.scalableToContain * layout.scale.scaleFactor
     t.ok(layout.scale.finalSvgHeight > largestSize)
+    return layout
   }
 
   testLongNodeChains([
@@ -341,6 +342,14 @@ test('Visualizer layout - scale - calculation height always greater thans longes
     ['1.1201.' + Array(399).fill(1202).map((num, index) => num + index).join('.'), 5],
     ['1.1601.' + Array(399).fill(1602).map((num, index) => num + index).join('.'), 5]
   ])
+
+  const layoutWithScaleModifier = testLongNodeChains([
+    // Small so scale factor is quite mild and scaledTotal can exceed svgHeight
+    ['1.2', 20],
+    // Just long enough to have an absolute just below the amount that fits in svgHeight
+    ['1.3.' + Array(20).fill(4).map((num, index) => num + index).join('.'), 5]
+  ])
+  t.equals(layoutWithScaleModifier.scale.decisiveWeight.modifier.toFixed(2), '0.57')
 
   /* TODO - fix error where this fails with error from arrayFlatten recursion being too deep
   // Very slow test - keep it commented out and uncomment as a smoke test for very large profile issues

--- a/test/visualizer-layout-scale.test.js
+++ b/test/visualizer-layout-scale.test.js
@@ -359,5 +359,15 @@ test('Visualizer layout - scale - calculation height always greater thans longes
   ])
   */
 
+  // Test interaction with node collapsing - ensure collapse threshold is adjusted when scale alone can't fit
+  settings.collapseNodes = true
+  const layoutAdjustedThreshold = testLongNodeChains([
+    // Everything tiny so initially almost nothing can be collapsed
+    ['1.2.3.4.5', 1],
+    // Long enough chain that absolute total exceeds svgHeight
+    ['1.6' + Array(26).fill(7).map((num, index) => num + index).join('.'), 1]
+  ])
+  t.equals(layoutAdjustedThreshold.collapsedLayout.collapseThreshold.toFixed(2), '26.10')
+
   t.end()
 })

--- a/test/visualizer-layout.test.js
+++ b/test/visualizer-layout.test.js
@@ -83,6 +83,13 @@ test('Visualizer layout - collapse - collapses vertically (except root and Ps)',
   t.deepEqual(actualAfter, ['1 => x1', 'x1 => 4', '4 => 5', '5 => '])
   t.deepEqual([ 2, 3 ], layout.layoutNodes.get('x1').collapsedNodes.map(layoutNode => layoutNode.id))
 
+  t.throws(() => {
+    const brokenLayout = new Layout({ dataNodes }, settings)
+    // Break the layout by giving a node a parent that isn't even in this layout
+    brokenLayout.layoutNodes.get(3).parent = layout.layoutNodes.get(2)
+    brokenLayout.generate()
+  }, new Error('Cannot combine nodes - clump/stem mismatch: 1=>2 + 3'))
+
   t.end()
 })
 

--- a/test/visualizer-layout.test.js
+++ b/test/visualizer-layout.test.js
@@ -439,12 +439,13 @@ test('Visualizer layout - collapse - naming', function (t) {
   layout = generateLayout(getNamedClusterNodes(dataSet, {
     3: 'a > a > a',
     4: 'b/e + bb',
-    5: 'c > c > c',
+    5: 'a > b > d',
     6: '... > d > d',
     7: 'b/e + ee',
-    8: 'c > c > c'
+    8: 'a > b > d'
   }), settings)
-  t.equal(layout.layoutNodes.get('x1').node.name, '…d… & a… & b/e… & c… & …bb')
+  // a… appears twice because everything in 'a > b > d' was already in the name, so falls back to [0]
+  t.equal(layout.layoutNodes.get('x1').node.name, '…d… & a… & b/e… & a… & …bb')
 
   t.end()
 })

--- a/visualizer/layout/collapsed-layout.js
+++ b/visualizer/layout/collapsed-layout.js
@@ -60,8 +60,9 @@ class CollapsedLayout {
         continueLoop = false
         let stemLengthAfterCollapse = 0
 
+        // This should be impossible - but in case some bug is introduced, a warning and break is better than an infinite loop
+        /* istanbul ignore next */
         if (this.collapseThreshold / multiplier > availableHeight) {
-          // This should be impossible - but in case some bug is introduced, a warning is better than an infinite loop
           const details = `LayoutNode ${layoutNode.id}'s ${ancestorIds.length}-length stem won't collapse to fit ${availableHeight}px.`
           console.warn(`Infinite loop prevented. ${details}`)
           break

--- a/visualizer/layout/layout.js
+++ b/visualizer/layout/layout.js
@@ -19,6 +19,10 @@ class Layout {
       svgHeight: 750,
       shortcutLength: 60,
       allowStretch: true,
+
+      // A static window height is used for node collapsing, so view contents are consistent regardless of window size etc
+      // 680 is based on common window sizes and tested to give reasonable collapsing
+      sizeIndependentHeight: 680,
       debugMode: false
     }
     this.settings = Object.assign(defaultSettings, settings)

--- a/visualizer/layout/layout.js
+++ b/visualizer/layout/layout.js
@@ -23,6 +23,7 @@ class Layout {
       // A static window height is used for node collapsing, so view contents are consistent regardless of window size etc
       // 680 is based on common window sizes and tested to give reasonable collapsing
       sizeIndependentHeight: 680,
+      initialCollapseThreshold: 10,
       debugMode: false
     }
     this.settings = Object.assign(defaultSettings, settings)

--- a/visualizer/layout/layout.js
+++ b/visualizer/layout/layout.js
@@ -234,6 +234,7 @@ class Layout {
   collapseNodes () {
     const collapsedLayout = new CollapsedLayout(this)
     this.layoutNodes = collapsedLayout.layoutNodes
+    if (this.settings.debugMode) this.collapsedLayout = collapsedLayout
   }
 
   getLayoutNodeSorter () {

--- a/visualizer/layout/scale.js
+++ b/visualizer/layout/scale.js
@@ -9,10 +9,6 @@ class Scale {
     this.layout = layout
     this.layoutNodes = null // set later
     this.heightMultiplier = 1 // applied to calculations here, and to threshold in collapse-layout.js
-
-    // Use a static window height before node collapsing, so view contents are consistent regardless of window size etc
-    // 680 is based on common window sizes and tested to give reasonable collapsing
-    this.sizeIndependentHeight = 680
   }
   // This simplified computation is necessary to ensure correct leaves order
   // when calculating the final scale factor
@@ -106,7 +102,7 @@ class Scale {
     }
     this.scaleFactor = validateNumber(this.decisiveWeight.weight)
 
-    const sizeIndependentHeight = this.sizeIndependentHeight * multiplier
+    const sizeIndependentHeight = this.layout.settings.sizeIndependentHeight * multiplier
     const sizeIndependentWeight = new ScaleWeight('size-independent', null, sizeIndependentHeight, longestStretched.scalableToContain, longestStretched.absoluteToContain)
     this.sizeIndependentScale = sizeIndependentWeight.weight
 
@@ -155,7 +151,7 @@ class Scale {
   }
 
   getScaleHeight (collapsed) {
-    return !this.isCollapsePending(collapsed) ? this.layout.settings.svgHeight : this.sizeIndependentHeight
+    return !this.isCollapsePending(collapsed) ? this.layout.settings.svgHeight : this.layout.settings.sizeIndependentHeight
   }
 
   getLineLength (dataValue) {

--- a/visualizer/layout/stems.js
+++ b/visualizer/layout/stems.js
@@ -48,13 +48,7 @@ class Stem {
   }
   update () {
     if (!this.lengths) {
-      const {
-        labelMinimumSpace,
-        lineWidth,
-        shortcutLength
-      } = this.layout.settings
-
-      const absolute = ((labelMinimumSpace * 2) + lineWidth) * this.ancestors.ids.length + shortcutLength * this.shortcutsInStem
+      const absolute = this.getAbsoluteLength()
       const scalable = this.ancestors.totalBetween + this.ancestors.totalDiameter + this.raw.ownBetween + this.raw.ownDiameter
       this.lengths = {
         absolute: validateNumber(absolute, this.getValidationMessage()),
@@ -73,6 +67,14 @@ class Stem {
       }
       this.lengths.scaledTotal = this.lengths.absolute + (this.lengths.scalable * this.layout.scale.scaleFactor)
     }
+  }
+  getAbsoluteLength (stemLength = this.ancestors.ids.length) {
+    const {
+      labelMinimumSpace,
+      lineWidth,
+      shortcutLength
+    } = this.layout.settings
+    return ((labelMinimumSpace * 2) + lineWidth) * stemLength + shortcutLength * this.shortcutsInStem
   }
   getValidationMessage () {
     return `for stem with:


### PR DESCRIPTION
Fixes the leftover issue described here where sometimes, a view can contain a chain of nodes just over the collapse threshold that contains too many nodes to fit into the space assigned for collapsing or a reasonable screen.

[note: these are still affected by the performance problem for super-large cluster nodes mentioned previously, so links to samples will be slow to load)

Before:

https://upload.clinicjs.org/public/cabda786c514e49ad25ad137dae1d14730c3146a95777a111b407a4e4abd5642/1005.clinic-bubbleprof.html#x4-c3

![image](https://user-images.githubusercontent.com/29628323/43779850-377097e0-9a51-11e8-94a3-f9aaf592ef21.png)

This PR does a pre-calculation before collapsing nodes to check that there won't be any stems too long (too many unscalable gaps between nodes) to be scaled to fit into a reasonable view. If so, it increases the collapse threshold, collapsing more nodes, and repeats until it has found a collapse threshold high enough that this view can be scaled to fit.

After:

![image](https://user-images.githubusercontent.com/29628323/43780061-a7c8b8d8-9a51-11e8-8cbf-290e25009cdd.png)

https://upload.clinicjs.org/public/1b66355f11e05b991c378cdbcbb8f841f424949fb8ad511cd1a10528bbf982f9/1005.clinic-bubbleprof.html#x4-c3