### PR TITLE
cut data streams when running low on memory

### DIFF
--- a/analysis/raw-event/join-as-raw-event.js
+++ b/analysis/raw-event/join-as-raw-event.js
@@ -67,6 +67,7 @@ class JoinAsRawEvent extends stream.Readable {
 
     if ((this._reads & 4095) === 0 && !hasFreeMemory()) {
       this._destroyed = true
+      this.emit('truncate')
       this.push(null)
       this._stackTrace.destroy()
       this._traceEvent.destroy()

--- a/analysis/raw-event/join-as-raw-event.js
+++ b/analysis/raw-event/join-as-raw-event.js
@@ -65,6 +65,7 @@ class JoinAsRawEvent extends stream.Readable {
     this._awaitRead = true
     this._reads++
 
+    /* istanbul ignore next */
     if ((this._reads & 4095) === 0 && !hasFreeMemory()) {
       this._destroyed = true
       this.emit('truncate')

--- a/index.js
+++ b/index.js
@@ -121,6 +121,8 @@ class ClinicBubbleprof extends events.EventEmitter {
     const nearFormLogoFile = fs.createReadStream(nearFormLogoPath)
     const clinicFaviconBase64 = fs.createReadStream(clinicFaviconPath)
 
+    dataFile.on('warning', msg => this.emit('warning', msg))
+
     // create script-file stream
     const b = browserify({
       'basedir': __dirname,


### PR DESCRIPTION
Did a lot of back and forth with this, but this seems to work quite nicely to solve #198

Basically ends the raw input data streams if more than 50% of the available heap has been used, and then only use that amount of data to do the analysis. When investigating this, it seems to produce the same amount of results as adding more memory.

For performance reasons it only checks the available heap every 4096 ticks.