### PR TITLE
Use specialised parser for speed boost

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "keywords": [],
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "JSONStream": "^1.3.1",
     "array-flatten": "^1.1.1",
     "async": "^2.5.0",
     "brfs": "^2.0.0",


### PR DESCRIPTION
Used `clinic flame` to profile latest bubbleprof a bunch and the flamegraph kept showing JSONStream being on the top of the stack *a lot*. This makes sense as we use a ton of time parsing the trace events data.

To try and speed it up I wrote a specialised parser for the trace events format. This resulted in a 2x speed boost on my machine. It's still on top of the stack a ton (@davidmarkclements would love to try using your optimised schema based JSON parse here to see if it has any effect).

### Before this PR:

```
time node $(which clinic) bubbleprof --visualize-only 25547.clinic-bubbleprof
Generated HTML file is 25547.clinic-bubbleprof.html
You can use this command to upload it:
clinic upload 25547.clinic-bubbleprof

real	0m10.103s
user	0m14.143s
sys	0m0.654s
```

Resulting flamegraph:

https://upload.clinicjs.org/public/b904d5dc93a0de2fac2de83155494f484624d48068c57d4cf3d083b38ed6d50e/7128.clinic-flame.html

### After this PR:

```
time node $(which clinic) bubbleprof --visualize-only 25547.clinic-bubbleprof
Generated HTML file is 25547.clinic-bubbleprof.html
You can use this command to upload it:
clinic upload 25547.clinic-bubbleprof

real	0m6.786s
user	0m10.987s
sys	0m0.528s
```

https://upload.clinicjs.org/public/29c7b9699c618fb0001f4afda4c67bc8571c38cc1b93987058c29271fabe5f3d/5759.clinic-flame.html

The raw data for the bench is available here:

https://upload.clinicjs.org/data/0f7164e9520b152581be9c772fcbedff68fc2f7c38d9c7edc3696abaf8c76116