### PR TITLE
Only sort clusterNode.nodes just before they are pushed. Fixes #242

### DIFF
--- a/analysis/cluster/cluster-node.js
+++ b/analysis/cluster/cluster-node.js
@@ -11,9 +11,19 @@ class ClusterNode {
     this.nodes = []
     this.children = []
     this.name = null
+
+    this._lastSort = 0
+  }
+
+  sort () {
+    if (this.nodes.length === this._lastSort) return
+    this._lastSort = this.nodes.length
+    this.nodes.sort(cmp)
   }
 
   [util.inspect.custom] (depth, options) {
+    this.sort()
+
     const nestedOptions = Object.assign({}, options, {
       depth: depth === null ? null : depth - 1
     })
@@ -51,6 +61,8 @@ class ClusterNode {
   }
 
   toJSON () {
+    this.sort()
+
     return {
       clusterId: this.clusterId,
       parentClusterId: this.parentClusterId,
@@ -71,8 +83,11 @@ class ClusterNode {
   insertBarrierNode (barrierNode) {
     if ((barrierNode.isRoot || !barrierNode.isWrapper) && !this.name) this.name = barrierNode.name
     this.nodes.push(...barrierNode.nodes)
-    this.nodes.sort((a, b) => a.aggregateId - b.aggregateId)
   }
 }
 
 module.exports = ClusterNode
+
+function cmp (a, b) {
+  return a.aggregateId - b.aggregateId
+}

--- a/analysis/cluster/combine-as-cluster-nodes.js
+++ b/analysis/cluster/combine-as-cluster-nodes.js
@@ -71,6 +71,7 @@ class CombineAsClusterNodes extends stream.Transform {
     const queue = [1] // root has barrierId = 1
     while (queue.length > 0) {
       const clusterNode = this._clusterNodeStroage.get(queue.shift())
+      clusterNode.sort()
       this.push(clusterNode)
 
       // Add children of the newly updated node to the queue

--- a/test/analysis-cluster.test.js
+++ b/test/analysis-cluster.test.js
@@ -200,6 +200,7 @@ test('Cluster Node - cluster.insertBarrierNode', function (t) {
   const clusterNodeForward = new ClusterNode(2, 1)
   clusterNodeForward.insertBarrierNode(barrierNodeCombined)
   clusterNodeForward.insertBarrierNode(barrierNodeWrapper)
+  clusterNodeForward.sort()
   t.strictDeepEqual(
     clusterNodeForward.nodes.map((aggregateNode) => aggregateNode.aggregateId),
     [2, 3, 6]
@@ -208,6 +209,7 @@ test('Cluster Node - cluster.insertBarrierNode', function (t) {
   const clusterNodeBackward = new ClusterNode(2, 1)
   clusterNodeBackward.insertBarrierNode(barrierNodeWrapper)
   clusterNodeBackward.insertBarrierNode(barrierNodeCombined)
+  clusterNodeBackward.sort()
   t.strictDeepEqual(
     clusterNodeBackward.nodes.map((aggregateNode) => aggregateNode.aggregateId),
     [2, 3, 6]


### PR DESCRIPTION
Makes the analysis ~20% faster on my machine on profiles that have a ton of clusters.

Works by only sorting the `clusterNode.nodes` array *just* before they are pushed to the pipeline (they aren't used before).

Might experiment with using [mafintosh/value-sort](https://github.com/mafintosh/value-sort) to speed it up even more, but this removes it as a hot method so good enough.

## Flame before

https://upload.clinicjs.org/public/3ab41478efac738d86e1536b98dcdd460fa3f29983f11473a6dc8a4e61a9077f/10715.clinic-flame.html

## Flame after

https://upload.clinicjs.org/public/c44fe8e71aa9a217b74efe40d2609fe1564df7d82ad57add5426ade72465c30c/10928.clinic-flame.html
