### PR TITLE
The format for the trace events changed partially

### DIFF
--- a/format/trace-event-decoder.js
+++ b/format/trace-event-decoder.js
@@ -22,6 +22,8 @@ class TraceEvent {
     this.timestamp = data.ts / 1000 // convert to ms
     this.triggerAsyncId = null
     this.executionAsyncId = null
+    // The trace event format changed in Node 11.0.0. To support both, old and
+    // new versions of Node, this checks for both data formats.
     const args = data.args.data || data.args
     if (args.hasOwnProperty('triggerAsyncId')) {
       this.triggerAsyncId = args.triggerAsyncId

--- a/format/trace-event-decoder.js
+++ b/format/trace-event-decoder.js
@@ -22,11 +22,12 @@ class TraceEvent {
     this.timestamp = data.ts / 1000 // convert to ms
     this.triggerAsyncId = null
     this.executionAsyncId = null
-    if (data.args.hasOwnProperty('triggerAsyncId')) {
-      this.triggerAsyncId = data.args.triggerAsyncId
+    const args = data.args.data || data.args
+    if (args.hasOwnProperty('triggerAsyncId')) {
+      this.triggerAsyncId = args.triggerAsyncId
     }
-    if (data.args.hasOwnProperty('executionAsyncId')) {
-      this.executionAsyncId = data.args.executionAsyncId
+    if (args.hasOwnProperty('executionAsyncId')) {
+      this.executionAsyncId = args.executionAsyncId
     }
   }
 }


### PR DESCRIPTION
This makes sure both formats are accepted.