### PR TITLE
Browser history support

### DIFF
--- a/visualizer/draw/area-chart.js
+++ b/visualizer/draw/area-chart.js
@@ -220,14 +220,17 @@ class AreaChart extends HtmlContent {
         const layoutNodeId = extractLayoutNodeId(d.key)
         if (!layoutNodeId) return
 
-        this.topmostUI.highlightNode(null)
+        this.topmostUI.queueAnimation('selectChartNode', (animationQueue) => {
+          this.topmostUI.highlightNode(null)
 
-        const layoutNode = this.topmostUI.layout.layoutNodes.get(layoutNodeId)
-        const targetUI = this.topmostUI.selectNode(layoutNode)
-        if (targetUI !== this.ui) {
-          this.ui.originalUI.emit('navigation', { from: this.ui, to: targetUI })
-        }
-        this.ui.highlightColour('type', null)
+          const layoutNode = this.topmostUI.layout.layoutNodes.get(layoutNodeId)
+          const targetUI = this.topmostUI.selectNode(layoutNode, animationQueue)
+          if (targetUI !== this.ui) {
+            this.ui.originalUI.emit('navigation', { from: this.ui, to: targetUI })
+          }
+          this.ui.highlightColour('type', null)
+          animationQueue.execute()
+        })
       })
       .on('mousemove', () => {
         this.showSlice(d3.event)

--- a/visualizer/draw/breadcrumb-panel.js
+++ b/visualizer/draw/breadcrumb-panel.js
@@ -64,9 +64,16 @@ class BreadcrumbPanel extends HtmlContent {
     }
   }
   traverseUp (targetUI) {
-    if (this.topmostUI !== targetUI) {
-      this.topmostUI.traverseUp(targetUI)
-    }
+    this.topmostUI.queueAnimation('breadcrumb', (animationQueue) => {
+      if (this.topmostUI !== targetUI) {
+        const currentUI = this.topmostUI.traverseUp(targetUI, { animationQueue })
+        if (currentUI !== targetUI) {
+          return
+        }
+      }
+      // Didn't animate, kick the queue
+      animationQueue.execute()
+    })
   }
 }
 

--- a/visualizer/draw/breadcrumb-panel.js
+++ b/visualizer/draw/breadcrumb-panel.js
@@ -67,7 +67,7 @@ class BreadcrumbPanel extends HtmlContent {
     this.topmostUI.queueAnimation('breadcrumb', (animationQueue) => {
       if (this.topmostUI !== targetUI) {
         const currentUI = this.topmostUI.traverseUp(targetUI, { animationQueue })
-        if (currentUI !== targetUI) {
+        if (this.topmostUI !== currentUI) {
           return
         }
       }

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -52,25 +52,7 @@ class BubbleprofUI extends EventEmitter {
     }
 
     if (this.originalUI === this) {
-      const nodeLinkSection = this.getNodeLinkSection()
-      this.backBtn = nodeLinkSection.addContent(undefined, {
-        hidden: true,
-        classNames: 'back-btn'
-      })
-      history.push(this)
-      this.on('navigation', ({ to, silent }) => {
-        history.push(to)
-        this.backBtn.isHidden = history.length < 2
-        this.backBtn.draw()
-
-        // Only update history if this navigation was not caused by history.
-        if (!silent) {
-          this.pushHistory(to.getHash())
-        }
-      })
-      this.on('setTopmostUI', (topMostUI) => {
-        this.topMostUI = topMostUI
-      })
+      this.setupHistory()
     }
   }
 
@@ -347,6 +329,28 @@ class BubbleprofUI extends EventEmitter {
     }
   }
 
+  setupHistory () {
+    const nodeLinkSection = this.getNodeLinkSection()
+    this.backBtn = nodeLinkSection.addContent(undefined, {
+      hidden: true,
+      classNames: 'back-btn'
+    })
+    history.push(this)
+    this.on('navigation', ({ to, silent }) => {
+      history.push(to)
+      this.backBtn.isHidden = history.length < 2
+      this.backBtn.draw()
+
+      // Only update history if this navigation was not caused by history.
+      if (!silent) {
+        this.pushHistory(to.getHash())
+      }
+    })
+    this.on('setTopmostUI', (topMostUI) => {
+      this.topMostUI = topMostUI
+    })
+  }
+
   pushHistory (hash) {
     window.history.pushState({ hash }, null, `#${hash || ''}`)
   }
@@ -369,6 +373,23 @@ class BubbleprofUI extends EventEmitter {
     }
     appendParentNode(uiWithinCollapsedNode.parentUI)
     return hashString
+  }
+
+  getHash () {
+    if (!this.layoutNode) {
+      return null
+    }
+
+    const dataNode = this.layoutNode.node
+    switch (dataNode.constructor.name) {
+      case 'ClusterNode':
+        return `c${dataNode.clusterId}`
+      case 'AggregateNode':
+        return `a${dataNode.aggregateId}`
+      case 'ArtificialNode':
+        return this.generateCollapsedNodeHash(this)
+    }
+    return null
   }
 
   parseCollapsedNodeHash () {
@@ -406,23 +427,6 @@ class BubbleprofUI extends EventEmitter {
         this.parseCollapsedNodeHash(window.location.hash)
         break
     }
-  }
-
-  getHash () {
-    if (!this.layoutNode) {
-      return null
-    }
-
-    const dataNode = this.layoutNode.node
-    switch (dataNode.constructor.name) {
-      case 'ClusterNode':
-        return `c${dataNode.clusterId}`
-      case 'AggregateNode':
-        return `a${dataNode.aggregateId}`
-      case 'ArtificialNode':
-        return this.generateCollapsedNodeHash(this)
-    }
-    return null
   }
 
   /**

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -700,7 +700,7 @@ class AnimationQueue {
     // overridable by users
   }
 
-  execute() {
+  execute () {
     console.log('execute animation queue', this.name)
     if (this.isExecuting) {
       return

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -671,13 +671,13 @@ class BubbleprofUI extends EventEmitter {
   }
 }
 
-let defaultQueueNameId = 0
 class AnimationQueue {
-  constructor (name = `Queue #${defaultQueueNameId++}`) {
+  // The createdIn argument is helpful when debugging animations. Best to pass it!
+  constructor (createdIn) {
     this.queue = []
     this.index = 0
     this.isExecuting = false
-    this.name = name
+    this.createdIn = createdIn
   }
 
   push (animation) {

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -370,7 +370,11 @@ class BubbleprofUI extends EventEmitter {
     // There is a `window.history.length` property, but it includes the entries
     // _before_ the current page (eg. the github issue that linked to this
     // visualization) so we can't use it here.
-    window.history.replaceState({ initial: true }, null, window.location.hash || '')
+    const hash = window.location.hash || ''
+    window.history.replaceState({
+      initial: true,
+      hash: hash.slice(1)
+    }, null, hash)
 
     this.on('navigation', ({ to, silent }) => {
       // Only update history if this navigation was not caused by history.
@@ -383,7 +387,7 @@ class BubbleprofUI extends EventEmitter {
     })
 
     window.addEventListener('popstate', (event) => {
-      const { hash } = event.state
+      const hash = event.state ? event.state.hash : ''
       if (this.topMostUI) {
         // Close stack frames when moving away from their node.
         if (this.topMostUI.selectedDataNode) {
@@ -665,7 +669,9 @@ class BubbleprofUI extends EventEmitter {
 
     if (window.location.hash) {
       setTimeout(() => {
-        this.jumpToHash(window.location.hash.slice(1))
+        this.queueAnimation('initial', (animationQueue) => {
+          this.jumpToHash(window.location.hash.slice(1), animationQueue)
+        })
       })
     }
 

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -372,10 +372,14 @@ class BubbleprofUI extends EventEmitter {
           this.topMostUI.jumpToHash(hash, this.historyAnimationQueue)
         } else {
           // If we don't have a hash, we're navigating to the original UI.
-          this.topMostUI.traverseUp(null, {
+          const targetUI = this.topMostUI.traverseUp(null, {
             silent: true,
             animationQueue: this.historyAnimationQueue
           })
+          if (targetUI === this) {
+            // Didn't queue any animations, just execute so onComplete() is called
+            this.historyAnimationQueue.execute()
+          }
         }
       }
 
@@ -601,6 +605,7 @@ class BubbleprofUI extends EventEmitter {
       this.originalUI.emit('navigation', { from: this, to: currentUI, silent })
       animationQueue.execute()
     }
+    return currentUI
   }
 
   // Back button goes back in user navigation one step at a time

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -407,6 +407,17 @@ class BubbleprofUI extends EventEmitter {
     let targetUI = this
     const animationQueue = []
 
+    // If we have any cluster nodes, we jump to that below first, and then drill
+    // into that node for collapsed nodes.
+    // But if all the nodes in the path are collapsed nodes, we start searching
+    // from the original UI. This is because collapsed nodes are only known
+    // in their parent layout, not globally (like cluster nodes).
+    if (nodeIds[nodeIds.length - 1].charAt(0) === 'x') {
+      while (targetUI.parentUI) {
+        targetUI = targetUI.clearSublayout(animationQueue)
+      }
+    }
+
     console.group(`parseCollapsedNodeHash ${hash}`)
     for (var i = nodeIds.length - 1; i >= 0; i--) {
       const nodeId = nodeIds[i]

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -222,6 +222,7 @@ class BubbleprofUI extends EventEmitter {
 
   // Selects a node visible within current layout
   selectNode (layoutNode, animationQueue) {
+    console.log('selectNode', { from: this.layoutNode, to: layoutNode })
     const dataNode = layoutNode.node
     const sameNode = this.selectedDataNode && this.selectedDataNode.uid === dataNode.uid
     this.svgNodeDiagram.svgNodes.get(layoutNode.id).select()
@@ -268,6 +269,8 @@ class BubbleprofUI extends EventEmitter {
 
   // Selects a node that may or may not be collapsed
   jumpToNode (dataNode, animationQueue = []) {
+    console.log('jumpToNode', { from: this.layoutNode, to: dataNode })
+
     if (this.layoutNode && this.layoutNode.node.uid === dataNode.uid) {
       executeAnimationQueue(animationQueue)
       return this
@@ -404,8 +407,10 @@ class BubbleprofUI extends EventEmitter {
     let targetUI = this
     const animationQueue = []
 
+    console.group(`parseCollapsedNodeHash ${hash}`)
     for (var i = nodeIds.length - 1; i >= 0; i--) {
       const nodeId = nodeIds[i]
+      console.log(nodeId, targetUI)
       if (nodeId.charAt(0) === 'x') {
         const layoutNode = targetUI.layout.layoutNodes.get(nodeId)
         targetUI = targetUI.selectNode(layoutNode, animationQueue)
@@ -415,6 +420,7 @@ class BubbleprofUI extends EventEmitter {
         targetUI = targetUI.jumpToNode(clusterNode, animationQueue)
       }
     }
+    console.groupEnd()
     this.originalUI.emit('navigation', { from: this, to: targetUI, silent: true })
   }
 

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -355,10 +355,8 @@ class BubbleprofUI extends EventEmitter {
     }
 
     if (ui.currentAnimationQueue) {
-      console.log('new animation', name, 'queue after', ui.currentAnimationQueue.createdIn)
       ui.currentAnimationQueue.next = executeAnimation
     } else {
-      console.log('new animation', name, 'execute')
       executeAnimation()
     }
   }
@@ -729,7 +727,6 @@ class AnimationQueue extends EventEmitter {
 
   executeNext () {
     if (!this.hasMoreAnimations()) {
-      console.log('animation', this.createdIn, 'onComplete')
       this.isExecuting = false
       this.emit('complete')
       this.next()
@@ -738,11 +735,8 @@ class AnimationQueue extends EventEmitter {
 
     this.isExecuting = true
     if (this.index === 0) {
-      console.log('animation', this.createdIn, 'start')
       this.queue.forEach(item => this.markUIPending(item))
     }
-
-    console.log('animation', this.createdIn, 'step', this.index)
 
     const {
       ui,

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -671,9 +671,9 @@ class BubbleprofUI extends EventEmitter {
   }
 }
 
-let aqn = 0
+let defaultQueueNameId = 0
 class AnimationQueue {
-  constructor (name = `Queue #${aqn++}`) {
+  constructor (name = `Queue #${defaultQueueNameId++}`) {
     this.queue = []
     this.index = 0
     this.isExecuting = false

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -399,7 +399,7 @@ class BubbleprofUI extends EventEmitter {
     return null
   }
 
-  parseCollapsedNodeHash (hash) {
+  jumpToCollapsedNodeHash (hash) {
     const nodeIds = hash.slice(1).split('-')
     let targetUI = this
     const animationQueue = []
@@ -418,7 +418,7 @@ class BubbleprofUI extends EventEmitter {
     this.originalUI.emit('navigation', { from: this, to: targetUI, silent: true })
   }
 
-  parseHash (hash) {
+  jumpToHash (hash) {
     const id = parseInt(hash.slice(1))
     switch (hash.charAt(0)) {
       case 'a':
@@ -432,7 +432,7 @@ class BubbleprofUI extends EventEmitter {
         this.originalUI.emit('navigation', { from: this, to: uiWithinCluster, silent: true })
         break
       case 'x':
-        this.parseCollapsedNodeHash(window.location.hash)
+        this.jumpToCollapsedNodeHash(window.location.hash)
         break
     }
   }
@@ -591,7 +591,7 @@ class BubbleprofUI extends EventEmitter {
 
     if (window.location.hash) {
       setTimeout(() => {
-        this.parseHash(window.location.hash.slice(1))
+        this.jumpToHash(window.location.hash.slice(1))
       })
     }
 
@@ -605,7 +605,7 @@ class BubbleprofUI extends EventEmitter {
       }
 
       if (hash) {
-        this.topMostUI.parseHash(hash)
+        this.topMostUI.jumpToHash(hash)
       } else {
         // If we don't have a hash, we're navigating to the original UI.
         this.topMostUI.traverseUp(null, { silent: true })

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -230,7 +230,6 @@ class BubbleprofUI extends EventEmitter {
 
   // Selects a node visible within current layout
   selectNode (layoutNode, animationQueue) {
-    console.log('selectNode', { from: this.layoutNode, to: layoutNode })
     const dataNode = layoutNode.node
     const sameNode = this.selectedDataNode && this.selectedDataNode.uid === dataNode.uid
     this.svgNodeDiagram.svgNodes.get(layoutNode.id).select()
@@ -277,8 +276,6 @@ class BubbleprofUI extends EventEmitter {
 
   // Selects a node that may or may not be collapsed
   jumpToNode (dataNode, animationQueue = new AnimationQueue('jumpToNode')) {
-    console.log('jumpToNode', { from: this.layoutNode, to: dataNode })
-
     if (this.layoutNode && this.layoutNode.node.uid === dataNode.uid) {
       animationQueue.execute()
       return this
@@ -459,10 +456,8 @@ class BubbleprofUI extends EventEmitter {
       }
     }
 
-    console.group(`parseCollapsedNodeHash ${hash}`)
     for (var i = nodeIds.length - 1; i >= 0; i--) {
       const nodeId = nodeIds[i]
-      console.log(nodeId, targetUI)
       if (nodeId.charAt(0) === 'x') {
         const layoutNode = targetUI.layout.layoutNodes.get(nodeId)
         targetUI = targetUI.selectNode(layoutNode, animationQueue)
@@ -473,7 +468,6 @@ class BubbleprofUI extends EventEmitter {
       }
     }
     animationQueue.execute()
-    console.groupEnd()
     this.originalUI.emit('navigation', { from: this, to: targetUI, silent: true })
   }
 
@@ -700,7 +694,6 @@ class AnimationQueue {
   }
 
   execute () {
-    console.log('execute animation queue', this.name)
     if (this.isExecuting) {
       return
     }
@@ -715,7 +708,6 @@ class AnimationQueue {
     if (!this.hasMoreAnimations()) {
       this.isExecuting = false
       this.onComplete()
-      console.log('completed animation queue', this.name)
       return
     }
 
@@ -730,7 +722,6 @@ class AnimationQueue {
       onAnimationStep
     } = this.queue[this.index]
 
-    console.log('stepping animation queue', this.name, this.index)
     this.index++
 
     ui.getNodeLinkSection().d3Element.classed('pending-animation', false)

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -338,6 +338,13 @@ class BubbleprofUI extends EventEmitter {
     }
   }
 
+  createHistoryAnimationQueue () {
+    this.historyAnimationQueue = new AnimationQueue('history')
+    this.historyAnimationQueue.onComplete = () => {
+      this.historyAnimationQueue = null
+    }
+  }
+
   setupHistory () {
     // Mark the current history entry (on page load) as the initial one.
     // There is a `window.history.length` property, but it includes the entries
@@ -379,10 +386,7 @@ class BubbleprofUI extends EventEmitter {
       // If we have don't have a history animation queue, create one and jump
       // immediately.
       if (!this.historyAnimationQueue) {
-        this.historyAnimationQueue = new AnimationQueue('history')
-        this.historyAnimationQueue.onComplete = () => {
-          this.historyAnimationQueue = null
-        }
+        this.createHistoryAnimationQueue()
         jump()
       } else {
         // If we have a history animation queue, that means we are
@@ -393,7 +397,7 @@ class BubbleprofUI extends EventEmitter {
         // back in the history, some in-between jumps will be skipped, but that
         // doesn't actually matter so long as the final state is correct.
         this.historyAnimationQueue.onComplete = () => {
-          this.historyAnimationQueue = new AnimationQueue('history')
+          this.createHistoryAnimationQueue()
           jump()
         }
       }

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -551,22 +551,19 @@ class BubbleprofUI extends EventEmitter {
   initializeBackButton () {
     this.backBtn.d3Element
       .classed('hidden', true)
-      .on('click', () => this.stepBack(this.topMostUI))
+      .on('click', () => this.stepBack())
 
     document.addEventListener('keydown', (e) => {
       if (e.keyCode === 8 && e.target.nodeName.toLowerCase() !== 'input') {
         // Backspace button
-        this.stepBack(this.topMostUI)
+        this.stepBack()
       }
     })
   }
 
-  stepBack (topMostUI) {
+  stepBack () {
     if (!this.hasHistoryEntries()) {
       return
-    }
-    if (topMostUI.selectedDataNode) {
-      return topMostUI.clearFrames()
     }
     window.history.back()
   }
@@ -599,7 +596,13 @@ class BubbleprofUI extends EventEmitter {
 
     window.addEventListener('popstate', (event) => {
       const { hash } = event.state
-      if (this.topMostUI) this.topMostUI.traverseUp(null, { silent: true })
+      if (this.topMostUI) {
+        this.topMostUI.traverseUp(null, { silent: true })
+        // Close stack frames when moving away from their node.
+        if (this.topMostUI.selectedDataNode) {
+          this.topMostUI.clearFrames()
+        }
+      }
       // If `hash` is nullish, we are navigating to the original UI,
       // which we just did using traverseUp() above.
       if (hash) this.parseHash(hash)

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -386,8 +386,10 @@ class BubbleprofUI extends EventEmitter {
       // If we have don't have a history animation queue, create one and jump
       // immediately.
       if (!this.historyAnimationQueue) {
+        console.log('history', 'jump')
         jump()
       } else {
+        console.log('history', 'queue')
         // If we have a history animation queue, that means we are
         // already animating; we should wait for that animation to complete
         // before jumping again.
@@ -711,6 +713,7 @@ class AnimationQueue {
 
   executeNext () {
     if (!this.hasMoreAnimations()) {
+      console.log('animation', this.createdIn, 'onComplete')
       this.isExecuting = false
       this.onComplete()
       return
@@ -718,8 +721,11 @@ class AnimationQueue {
 
     this.isExecuting = true
     if (this.index === 0) {
+      console.log('animation', this.createdIn, 'start')
       this.queue.forEach(item => this.markUIPending(item))
     }
+
+    console.log('animation', this.createdIn, 'step', this.index)
 
     const {
       ui,

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -402,16 +402,17 @@ class BubbleprofUI extends EventEmitter {
   parseCollapsedNodeHash (hash) {
     const nodeIds = hash.slice(1).split('-')
     let targetUI = this
+    const animationQueue = []
 
     for (var i = nodeIds.length - 1; i >= 0; i--) {
       const nodeId = nodeIds[i]
       if (nodeId.charAt(0) === 'x') {
         const layoutNode = targetUI.layout.layoutNodes.get(nodeId)
-        targetUI = targetUI.selectNode(layoutNode)
+        targetUI = targetUI.selectNode(layoutNode, animationQueue)
       } else {
         const clusterId = parseInt(nodeId.slice(1))
         const clusterNode = this.dataSet.clusterNodes.get(clusterId)
-        targetUI = targetUI.jumpToNode(clusterNode)
+        targetUI = targetUI.jumpToNode(clusterNode, animationQueue)
       }
     }
     this.originalUI.emit('navigation', { from: this, to: targetUI, silent: true })

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -420,6 +420,7 @@ class BubbleprofUI extends EventEmitter {
         targetUI = targetUI.jumpToNode(clusterNode, animationQueue)
       }
     }
+    executeAnimationQueue(animationQueue)
     console.groupEnd()
     this.originalUI.emit('navigation', { from: this, to: targetUI, silent: true })
   }

--- a/visualizer/draw/frames.js
+++ b/visualizer/draw/frames.js
@@ -140,8 +140,10 @@ class Frames extends HtmlContent {
                 this.topmostUI.highlightNode(null)
               })
               .on('click', () => {
-                const targetUI = this.topmostUI.jumpToNode(frame.dataNode)
-                this.topmostUI.originalUI.emit('navigation', { from: this.ui, to: targetUI })
+                this.topmostUI.queueAnimation('jumpToFrame', (animationQueue) => {
+                  const targetUI = this.topmostUI.jumpToNode(frame.dataNode, animationQueue)
+                  this.topmostUI.originalUI.emit('navigation', { from: this.ui, to: targetUI })
+                })
               })
           }
 

--- a/visualizer/draw/hover-box.js
+++ b/visualizer/draw/hover-box.js
@@ -237,10 +237,13 @@ class HoverBox extends HtmlContent {
     const clickHandler = () => {
       d3.event.stopPropagation()
       this.ui.highlightNode(null)
-      const targetUI = this.ui.selectNode(layoutNode)
-      if (targetUI !== this.ui) {
-        this.ui.originalUI.emit('navigation', { from: this.ui, to: targetUI })
-      }
+      this.ui.queueAnimation('selectHoverBoxNode', (animationQueue) => {
+        const targetUI = this.ui.selectNode(layoutNode, animationQueue)
+        if (targetUI !== this.ui) {
+          this.ui.originalUI.emit('navigation', { from: this.ui, to: targetUI })
+        }
+        animationQueue.execute()
+      })
     }
     this.d3TitleBlock.on('click', clickHandler)
     this.d3VerticalArrow.on('click', clickHandler)

--- a/visualizer/draw/lookup.js
+++ b/visualizer/draw/lookup.js
@@ -147,10 +147,12 @@ class Lookup extends HtmlContent {
         this.topmostUI.highlightNode(null)
       })
       .on('click', () => {
-        const targetUI = this.topmostUI.jumpToNode(dataNode)
-        if (targetUI !== this.ui) {
-          this.ui.originalUI.emit('navigation', { from: this.ui, to: targetUI })
-        }
+        this.topmostUI.queueAnimation('searchFrame', (animationQueue) => {
+          const targetUI = this.topmostUI.jumpToNode(dataNode, animationQueue)
+          if (targetUI !== this.ui) {
+            this.ui.originalUI.emit('navigation', { from: this.ui, to: targetUI })
+          }
+        })
       })
   }
 

--- a/visualizer/draw/svg-node-diagram.js
+++ b/visualizer/draw/svg-node-diagram.js
@@ -61,10 +61,13 @@ class SvgNodeDiagram {
       .on('mouseleave', () => this.ui.highlightNode(null))
       .on('click', (layoutNode) => {
         d3.event.stopPropagation()
-        const targetUI = this.ui.selectNode(layoutNode)
-        if (targetUI !== this.ui) {
-          this.ui.originalUI.emit('navigation', { from: this.ui, to: targetUI })
-        }
+        this.ui.queueAnimation('selectGraphNode', (animationQueue) => {
+          const targetUI = this.ui.selectNode(layoutNode, animationQueue)
+          if (targetUI !== this.ui) {
+            this.ui.originalUI.emit('navigation', { from: this.ui, to: targetUI })
+          }
+          animationQueue.execute()
+        })
       })
   }
 

--- a/visualizer/draw/svg-node-diagram.js
+++ b/visualizer/draw/svg-node-diagram.js
@@ -9,8 +9,6 @@ class SvgNodeDiagram {
     this.svgContainer = svgContainer
     this.ui = svgContainer.ui
 
-    this.onAnimationComplete = []
-
     this.svgNodes = new Map()
 
     this.ui.on('initializeFromData', () => {


### PR DESCRIPTION
This patch replaces the `history` array and hash URLs with a `pushState` based solution. For clarity I'll refer to the `history` array that stored UI instances as `customHistory`.

Demo: https://upload.clinicjs.org/public/02047f8379fae585fcdc17a644648fcd765fa46aa20ddf355761dafaae8698ae/2575.clinic-bubbleprof.html

TODO:

 - [x] When flicking through the history very quickly, animations are not queued, so you may still end up with multiple layouts showing at once.
 - [x] Returning to a top level collapsed node (eg #x3) does not work
 - [x] Remove debug logging stuff

Details:

 - On load, we set the current history state to `{ initial: true }` using `replaceState`. We can then do `!window.history.state.initial` to check if we have any entries in the history, instead of checking `customHistory.length`, to decide if the back button should be shown.
 - BubbleprofUI instances now have a `getHash()` method that returns a URL-compatible ID, just like the `location.hash` assignments before
 - On Bubbleprof 'navigation' events, we call `getHash()` on the `to` argument, and push the hash to the history using `pushState()`.
 - On browser 'popstate' events, we
   1. clear all sublayouts using `traverseUp()`—to do this I moved the 'setTopmostUI' handler from the close button method to `setupHistory()`. It _could_ be in the constructor but that would prevent GC of all layouts I think? It's only used by the history code which is only run in the root/original UI.
   2. parse the hash just like the `location.hash` parsing did on load before, passing `{silent: true}` to the 'navigation' event to prevent it from doing `pushState()` again
   3. show or hide the back button depending on the `history.state.initial` value
 - when the back button is clicked, we now just use the `history.back()` browser API which will trigger 'popstate'.

Q:

- Does 'navigation' ever have a `to` argument that's not a BubbleprofUI instance? This patch assumes `to` is always a BubbleprofUI. I clicked around a lot so I don't think so, but maybe I missed a button.

Fixes #158