### PR TITLE
Throw error if a cluster subprocess is forked

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ class ClinicBubbleprof extends events.EventEmitter {
   collect (args, callback) {
     // run program, but inject the sampler
     const logArgs = [
+      '-r', 'no-cluster.js',
       '-r', 'logger.js',
       '--trace-events-enabled', '--trace-event-categories', 'node.async_hooks'
     ]

--- a/injects/no-cluster.js
+++ b/injects/no-cluster.js
@@ -1,0 +1,5 @@
+const cluster = require('cluster')
+
+cluster.on('fork', () => {
+  throw new Error('clinic bubbleprof does not support clustering.')
+})

--- a/test/cmd-no-cluster.script.js
+++ b/test/cmd-no-cluster.script.js
@@ -1,0 +1,11 @@
+const rimraf = require('rimraf')
+const ClinicBubbleprof = require('../index.js')
+
+const bubble = new ClinicBubbleprof({})
+bubble.collect([
+  process.execPath,
+  '-e', 'var c = require("cluster"); c.isMaster && c.fork()'
+], (err, result) => {
+  rimraf.sync(result)
+  if (err) throw err
+})

--- a/test/cmd-no-cluster.test.js
+++ b/test/cmd-no-cluster.test.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const test = require('tap').test
+const { spawn } = require('child_process')
+const endpoint = require('endpoint')
+const rimraf = require('rimraf')
+const ClinicBubbleprof = require('../index.js')
+
+test('collect command stops when cluster is used', function (t) {
+  t.plan(3)
+
+  const bubble = new ClinicBubbleprof({})
+  bubble.collect([process.execPath, '-e', 'require("cluster")'], (err, result) => {
+    t.ifError(err, 'should not crash when cluster is required but not used')
+    rimraf.sync(result)
+  })
+
+  const proc = spawn(process.execPath, [
+    require.resolve('./cmd-no-cluster.script.js')
+  ], { stdio: 'pipe' })
+
+  proc.stderr.pipe(endpoint((err, buf) => {
+    t.ifError(err)
+    t.ok(buf.toString('utf8').includes('does not support clustering'), 'should crash once cluster is used')
+  }))
+})


### PR DESCRIPTION
See https://github.com/davidmarkclements/0x/pull/155

The test that does `cluster.fork()` generates output so I moved that into a subprocess. The test that just does `require('cluster')` doesn't generate any output so I left it inline.