### PR TITLE
Only redraw area chart paths when necessary

### DIFF
--- a/visualizer/draw/area-chart.js
+++ b/visualizer/draw/area-chart.js
@@ -19,6 +19,7 @@ class AreaChart extends HtmlContent {
       }
     }, contentProperties))
 
+    this.initialized = false
     this.topmostUI = this.ui
     this.xScale = d3.scaleTime()
     this.yScale = d3.scaleLinear()
@@ -151,16 +152,20 @@ class AreaChart extends HtmlContent {
     }
   }
   initializeFromData () {
-    // Same behaviour on mouse movements off coloured area as on
-    this.d3AreaChartSVG.on('mousemove', () => {
-      this.showSlice(d3.event)
-    })
+    if (!this.initialized) {
+      // These actions aren't redone when data changes, but must be done after data was set
+      this.initialized = true
 
-    this.d3ContentWrapper.on('mouseleave', () => {
-      this.hoverBox.hide()
-      this.d3SliceHighlight.classed('hidden', true)
-    })
+      // Same behaviour on mouse movements off coloured area as on
+      this.d3AreaChartSVG.on('mousemove', () => {
+        this.showSlice(d3.event)
+      })
 
+      this.d3ContentWrapper.on('mouseleave', () => {
+        this.hoverBox.hide()
+        this.d3SliceHighlight.classed('hidden', true)
+      })
+    }
     if (this.contentProperties.static) this.d3LeadInText.html(this.getLeadInText())
     if (!this.d3AreaPaths) this.createPathsForLayout()
   }

--- a/visualizer/draw/area-chart.js
+++ b/visualizer/draw/area-chart.js
@@ -51,6 +51,7 @@ class AreaChart extends HtmlContent {
         })
       }
 
+      this.createPathsForLayout()
       this.draw()
     })
   }
@@ -161,6 +162,7 @@ class AreaChart extends HtmlContent {
     })
 
     if (this.contentProperties.static) this.d3LeadInText.html(this.getLeadInText())
+    if (!this.d3AreaPaths) this.createPathsForLayout()
   }
   createPathsForLayout () {
     if (this.d3AreaPaths) this.d3AreaPaths.remove()
@@ -294,8 +296,6 @@ class AreaChart extends HtmlContent {
     this.hoverBox.d3Element.classed('off-bottom', true)
   }
   draw () {
-    this.createPathsForLayout()
-
     super.draw()
     const {
       width,

--- a/visualizer/draw/area-chart.js
+++ b/visualizer/draw/area-chart.js
@@ -239,7 +239,10 @@ class AreaChart extends HtmlContent {
   applyLayoutNode (layoutNode = null) {
     const redraw = layoutNode !== this.layoutNode
     this.layoutNode = layoutNode
-    if (redraw) this.draw()
+    if (redraw) {
+      this.createPathsForLayout()
+      this.draw()
+    }
   }
   layoutNodeHasAggregateId (aggregateId) {
     const aggregateNode = this.getAggregateNode(aggregateId)


### PR DESCRIPTION
As mentioned in this review comment - https://github.com/nearform/node-clinic-bubbleprof/pull/264#issuecomment-419414256

We can improve the performance of AreaChart.draw() enough to call it without debouncing on resizing the containing window, if we stop calling AreaChart.createPathsForLayout() on every draw event and instead call it only when needed: 

 - on first initialisation of the chart
 - on a change to the main layout or sublayout being viewed
 - for the chart within the hover box, on hovering a new node

Should be no appearance or functionality changes, just improved efficiency on draw() events that include the area chart.