### PR TITLE
Correct typo, "Seperator" -> "Separator", with backwards compatibility for old data

### DIFF
--- a/analysis/stack-trace/frames.js
+++ b/analysis/stack-trace/frames.js
@@ -38,11 +38,11 @@ class Frame {
     // evals and natives are not in nodecore
     if (this.isEval || this.isNative) return false
 
-    if (fileName.startsWith(`internal${systemInfo.pathSeperator}`)) {
+    if (fileName.startsWith(`internal${systemInfo.pathSeparator}`)) {
       return true
     }
 
-    return !fileName.includes(systemInfo.pathSeperator)
+    return !fileName.includes(systemInfo.pathSeparator)
   }
 
   getFileNameWithoutModuleDirectory (systemInfo) {
@@ -70,20 +70,20 @@ class Frame {
 
     // If the remaining path contains node_modules it is external
     return this.getFileNameWithoutModuleDirectory(systemInfo)
-      .split(systemInfo.pathSeperator)
+      .split(systemInfo.pathSeparator)
       .includes('node_modules')
   }
 
   anonymise (systemInfo) {
     if (this.isNodecore(systemInfo) || !this.fileName || this.fileName[0] === '.') return
-    const { relative } = (systemInfo.pathSeperator === '/' ? path.posix : path.win32)
+    const { relative } = (systemInfo.pathSeparator === '/' ? path.posix : path.win32)
     const rel = relative(systemInfo.mainDirectory, this.fileName)
     if (!rel || rel[0] === '.') this.fileName = rel
-    else this.fileName = '.' + systemInfo.pathSeperator + rel
+    else this.fileName = '.' + systemInfo.pathSeparator + rel
   }
 
   getModuleName (systemInfo) {
-    const filePath = this.fileName.split(systemInfo.pathSeperator)
+    const filePath = this.fileName.split(systemInfo.pathSeparator)
     if (!filePath.includes('node_modules')) return null
 
     // Find the last node_modules directory, and count how many were

--- a/analysis/system-info.js
+++ b/analysis/system-info.js
@@ -3,8 +3,10 @@
 class SystemInfo {
   constructor (data) {
     this.providers = new Set(data.providers)
-    this.pathSeparator = data.pathSeparator
     this.mainDirectory = data.mainDirectory
+
+    // Backwards compatibility with data collected in Bubbleprof <1.6.1, which contained a typo
+    this.pathSeparator = data.pathSeparator || data.pathSeperator
 
     // Compute self-module directory for the special case that the main script
     // itself is in a node_modules directory.

--- a/analysis/system-info.js
+++ b/analysis/system-info.js
@@ -3,13 +3,13 @@
 class SystemInfo {
   constructor (data) {
     this.providers = new Set(data.providers)
-    this.pathSeperator = data.pathSeperator
+    this.pathSeparator = data.pathSeparator
     this.mainDirectory = data.mainDirectory
 
     // Compute self-module directory for the special case that the main script
     // itself is in a node_modules directory.
     const mainDirectoryPath = this.mainDirectory
-      .split(this.pathSeperator)
+      .split(this.pathSeparator)
     if (mainDirectoryPath.includes('node_modules')) {
       let mainDirectoryIndex = mainDirectoryPath.lastIndexOf('node_modules')
       // module is in a @namespace
@@ -22,7 +22,7 @@ class SystemInfo {
       // Join up the path, it will look like:
       // "/home/user/node_modules/@private/server"
       this.moduleDirectory = mainDirectoryPath.slice(0, mainDirectoryIndex + 1)
-        .join(this.pathSeperator)
+        .join(this.pathSeparator)
     } else {
       this.moduleDirectory = ''
     }

--- a/collect/system-info.js
+++ b/collect/system-info.js
@@ -29,7 +29,7 @@ function systemInfo () {
       'TickObject', 'Timeout', 'Immediate',
       ...Object.keys(asyncWrap.Providers)
     ],
-    pathSeperator: require('path').sep,
+    pathSeparator: require('path').sep,
     mainDirectory: getMainDirectory()
   }
 }

--- a/test/analysis-util/system-info.js
+++ b/test/analysis-util/system-info.js
@@ -10,7 +10,7 @@ class FakeSystemInfo extends SystemInfo {
         'TickObject', 'Timeout', 'Immediate',
         ...Object.keys(asyncWrap.Providers)
       ],
-      pathSeperator: '/',
+      pathSeparator: '/',
       mainDirectory: mainDirectory // test directory
     })
   }

--- a/test/analysis.test.js
+++ b/test/analysis.test.js
@@ -65,7 +65,7 @@ function createInputStream (frames) {
   const systemInfoParsed = new FakeSystemInfo('/')
   const systemInfoData = [{
     providers: systemInfoParsed.providers,
-    pathSeperator: systemInfoParsed.pathSeperator,
+    pathSeparator: systemInfoParsed.pathSeparator,
     mainDirectory: systemInfoParsed.mainDirectory
   }]
 

--- a/visualizer/draw/svg-node-section.js
+++ b/visualizer/draw/svg-node-section.js
@@ -423,7 +423,7 @@ function addMissingADefs (arcString) {
   return unpackArcString(`${firstStringSection} A 0,0,0,0,1,0,0`)
 }
 
-function splitBySvgSeperator (substring) {
+function splitBySvgSeparator (substring) {
   const byComma = substring.trim().split(',')
 
   // MS Edge writes SVG seperated by spaces not commas e.g. 'M 1.23 4.56' not 'M 1.23,4.56'
@@ -439,8 +439,8 @@ function unpackArcString (initialString, alreadyFiltered = false) {
     A: []
   }
   arcArray.forEach(subStr => {
-    if (subStr.charAt(0) === 'M') unfilteredArc.M.push(splitBySvgSeperator(subStr.slice(1).trim()))
-    if (subStr.charAt(0) === 'A') unfilteredArc.A.push(splitBySvgSeperator(subStr.slice(1).trim()))
+    if (subStr.charAt(0) === 'M') unfilteredArc.M.push(splitBySvgSeparator(subStr.slice(1).trim()))
+    if (subStr.charAt(0) === 'A') unfilteredArc.A.push(splitBySvgSeparator(subStr.slice(1).trim()))
   })
 
   const filteredArc = {


### PR DESCRIPTION
Spelling "separate" and its variants as "seperate" like this is apparently one of the most common spelling mistakes in English. We had some issues in Flame caused by using similar system info logic to this (containing the typo) then other code using the correct spelling. So, best to have correct spelling everywhere.

Since data collected before this PR will have written `pathSeperator` into the system-info files, this checks for either `pathSeperator` or `pathSeparator` when reading system info, so that `visualize-only` and `visualize-all` still work on old samples.