### PR TITLE
Adding `visualize-watch`: it makes use of `chokidar` to watch for cha…

### DIFF
--- a/debug/visualize-all.js
+++ b/debug/visualize-all.js
@@ -1,23 +1,3 @@
 #!/usr/bin/env node
-
-const Tool = require('../')
-
-for (const file of process.argv.slice(2).map(trim)) {
-  const tool = new Tool({ debug: true })
-
-  tool.visualize(
-    file,
-    file + '.html',
-    function (err) {
-      if (err) {
-        console.error(file, 'failed (' + err.message + ')')
-      } else {
-        console.log('Wrote', file + '.html')
-      }
-    }
-  )
-}
-
-function trim (file) {
-  return file.replace(/\/\\$/, '')
-}
+var v = require('./visualize-mod.js')
+v.visualize({ debug: true })

--- a/debug/visualize-mod.js
+++ b/debug/visualize-mod.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+const Tool = require('../')
+
+module.exports = {
+  visualize: () => {
+    for (const file of process.argv.slice(2).map(trim)) {
+      const tool = new Tool({ debug: true })
+
+      tool.visualize(
+        file,
+        file + '.html',
+        function (err) {
+          if (err) {
+            throw err
+          } else {
+            console.log('Wrote', file + '.html')
+          }
+        }
+      )
+    }
+  }
+}
+
+function trim (file) {
+  return file.replace(/\/\\$/, '')
+}

--- a/debug/visualize-watch.js
+++ b/debug/visualize-watch.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+var chokidar = require('chokidar')
+var v = require('./visualize-mod.js')
+
+const debounce = require('lodash.debounce')
+
+// this is useful when updating multiple files in just one go (i.e. checking-out a branch)
+const debVisualize = debounce(v.visualize, 100)
+
+chokidar
+  .watch([
+    'visualizer/**/*.css',
+    'visualizer/**/*.js',
+    'index.js'
+  ], {
+    ignoreInitial: true
+  })
+  .on('all', (event, path) => {
+    console.log(event, path)
+    debVisualize()
+  })
+
+v.visualize()

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "ci-test": "tap test/*.test.js",
     "ci-cov": "tap --statements=98 test/*.test.js",
     "lint": "standard --fix | snazzy",
+    "visualize-watch": "node debug/visualize-watch.js",
     "visualize-all": "node debug/visualize-all.js"
   },
   "devDependencies": {
+    "chokidar": "^2.0.4",
     "cross-platform-sock": "^1.0.0",
     "express": "^4.16.2",
     "inspectpoint": "^0.2.2",


### PR DESCRIPTION
Just a convenient script to automatically run `visualize-all` whenever something changes in a `js` or `css` file