### PR TITLE
Add --dest flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ const bubbleprof = new ClinicBubbleprof()
   * detectPort [`<boolean>`][] **Default**: false
   * debug [`<boolean>`][] If set to true, the generated html will not be minified.
     **Default**: false
+  * dest [`<String>`][] The folder where the collected data is stored.
+    **Default**: '.'
 
 #### `bubbleprof.collect(args, callback)`
 
@@ -89,3 +91,4 @@ arguments, except a possible error.
 [appveyor-url]: https://ci.appveyor.com/project/nearForm/node-clinic-bubbleprof/branch/master
 [`<Object>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
 [`<boolean>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type
+[`<String>`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String

--- a/injects/logger.js
+++ b/injects/logger.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const fs = require('fs')
+const makeDir = require('mkdirp')
 const asyncHooks = require('async_hooks')
 const stackTrace = require('../collect/stack-trace.js')
 const systemInfo = require('../collect/system-info.js')
@@ -12,7 +13,7 @@ const paths = getLoggingPaths({
   path: process.env.NODE_CLINIC_BUBBLEPROF_DATA_PATH,
   identifier: process.pid
 })
-fs.mkdirSync(paths['/'])
+makeDir.sync(paths['/'])
 
 // write system file
 fs.writeFileSync(paths['/systeminfo'], JSON.stringify(systemInfo(), null, 2))

--- a/injects/logger.js
+++ b/injects/logger.js
@@ -8,7 +8,10 @@ const StackTraceEncoder = require('../format/stack-trace-encoder.js')
 const getLoggingPaths = require('@nearform/clinic-common').getLoggingPaths('bubbleprof')
 
 // create dirname
-const paths = getLoggingPaths({ identifier: process.pid })
+const paths = getLoggingPaths({
+  path: process.env.NODE_CLINIC_BUBBLEPROF_DATA_PATH,
+  identifier: process.pid
+})
 fs.mkdirSync(paths['/'])
 
 // write system file

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lodash": "^4.14.0",
     "loose-envify": "^1.4.0",
     "minify-stream": "^1.2.0",
+    "mkdirp": "^0.5.1",
     "node-trace-log-join": "^1.0.0",
     "on-net-listen": "^1.0.0",
     "protocol-buffers": "^4.0.4",

--- a/test/cmd-dest.test.js
+++ b/test/cmd-dest.test.js
@@ -8,7 +8,7 @@ test('cmd - test collect - custom output destination', (t) => {
 
   function cleanup (err, dirname) {
     t.ifError(err)
-    t.match(dirname, /^test-output-destination\/[0-9]+\.clinic-bubbleprof$/)
+    t.match(dirname, /^test-output-destination[\/\\][0-9]+\.clinic-bubbleprof$/)
 
     rimraf('test-output-destination', (err) => {
       t.ifError(err)

--- a/test/cmd-dest.test.js
+++ b/test/cmd-dest.test.js
@@ -1,0 +1,35 @@
+const test = require('tap').test
+const fs = require('fs')
+const rimraf = require('rimraf')
+const ClinicBubbleprof = require('../index.js')
+
+test('cmd - test collect - custom output destination', (t) => {
+  const tool = new ClinicBubbleprof({ debug: true, dest: 'test-output-destination' })
+
+  function cleanup (err, dirname) {
+    t.ifError(err)
+    t.match(dirname, /^test-output-destination\/[0-9]+\.clinic-bubbleprof$/)
+
+    rimraf('test-output-destination', (err) => {
+      t.ifError(err)
+      t.end()
+    })
+  }
+
+  tool.collect(
+    [process.execPath, '-e', 'setTimeout(() => {}, 200)'],
+    function (err, dirname) {
+      if (err) return cleanup(err, dirname)
+
+      t.ok(fs.statSync(dirname).isDirectory())
+
+      tool.visualize(dirname, `${dirname}.html`, (err) => {
+        if (err) return cleanup(err, dirname)
+
+        t.ok(fs.statSync(`${dirname}.html`).isFile())
+
+        cleanup(null, dirname)
+      })
+    }
+  )
+})

--- a/test/cmd-dest.test.js
+++ b/test/cmd-dest.test.js
@@ -8,7 +8,7 @@ test('cmd - test collect - custom output destination', (t) => {
 
   function cleanup (err, dirname) {
     t.ifError(err)
-    t.match(dirname, /^test-output-destination[\/\\][0-9]+\.clinic-bubbleprof$/)
+    t.match(dirname, /^test-output-destination[/\\][0-9]+\.clinic-bubbleprof$/)
 
     rimraf('test-output-destination', (err) => {
       t.ifError(err)


### PR DESCRIPTION
Passes the value of `options.dest` to `getLoggingPaths()` calls, basically in an identical way as Doctor.

mkdirp is now needed in injects/logger.js because the output path isn't always just a single directory inside the working directory anymore.