### PR TITLE
move minify to end of pipeline and avoid minifying data. fixes #273 ...

### DIFF
--- a/lib/minify-inline.js
+++ b/lib/minify-inline.js
@@ -1,7 +1,15 @@
+'use strict'
+
 const terser = require('terser')
 const fs = require('fs')
 
 module.exports = minifyInline
+
+// Accepts an html file and minifies the first script tag it finds.
+// It tries to find the inlined bubbleprof data also (data.json)
+// and before doing the minification process it replaces the data
+// with a tmp placeholder. This massively reduces the memory overhead
+// and likewise increases the perf by many magnitudes.
 
 function minifyInline (filename, opts, cb) {
   fs.readFile(filename, 'utf-8', function (err, data) {
@@ -14,7 +22,7 @@ function minifyInline (filename, opts, cb) {
 
     const src = data.slice(start + 8, end) // + 8 === <script>.length
     const magicPrefix = 'module.exports={"data":['
-    const magic = '"__MAGIC_MINIFY_UNIQUE_STRING_TO_BE_REPLACED__"'
+    const magic = '"__MAGIC_MINIFY_STRING_THAT_SHOULD_BE_REPLACED__"'
     const open = data.slice(0, start + 8)
     const close = data.slice(end)
 

--- a/lib/minify-inline.js
+++ b/lib/minify-inline.js
@@ -1,0 +1,35 @@
+const terser = require('terser')
+const fs = require('fs')
+
+module.exports = minifyInline
+
+function minifyInline (filename, opts, cb) {
+  fs.readFile(filename, 'utf-8', function (err, data) {
+    if (err) return cb(err)
+
+    const start = data.indexOf('<script>')
+    const end = data.lastIndexOf('</script>')
+
+    if (start === -1 || end === -1) return cb(new Error('Must contain <script> and </script> tags'))
+
+    const src = data.slice(start + 8, end) // + 8 === <script>.length
+    const magicPrefix = 'module.exports={"data":['
+    const magic = '"__MAGIC_MINIFY_UNIQUE_STRING_TO_BE_REPLACED__"'
+    const open = data.slice(0, start + 8)
+    const close = data.slice(end)
+
+    const i = src.indexOf(magicPrefix)
+    const j = src.indexOf('],"httpRequests":', i)
+    const magicSrc = i !== -1 && j !== -1
+      ? src.slice(0, i) + magicPrefix + magic + src.slice(j)
+      : src
+
+    data = null // try to help gc as the data might be +100mbs ...
+
+    const minified = terser.minify(magicSrc, opts)
+    if (minified.error) return cb(minified.error)
+    const code = minified.code.replace(magic, src.slice(i + magicPrefix.length, j))
+
+    fs.writeFile(filename, open + code + close, cb)
+  })
+}

--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
     "endpoint": "^0.4.5",
     "lodash": "^4.14.0",
     "loose-envify": "^1.4.0",
-    "minify-stream": "^1.2.0",
     "mkdirp": "^0.5.1",
     "node-trace-log-join": "^1.0.0",
     "on-net-listen": "^1.0.0",
     "protocol-buffers": "^4.0.4",
     "pump": "^3.0.0",
-    "stream-template": "0.0.10"
+    "stream-template": "0.0.10",
+    "terser": "^3.10.11"
   }
 }


### PR DESCRIPTION
… and https://github.com/nearform/node-clinic/issues/72

Currently the minification pipeline will run out of memory on even pretty small analysises as it's trying to minify all the inlined data, which doesn't make a lot of sense.

This PR fixes this by applying two changes.

It moves the minification to after the the viz pipeline has finished (it needs to buffer anyway, see the source of minify-stream). This should in theory free up all the memory used by the analysis to be avail for minification but there seems to be a leak somewhere (TODO: investigate why node keeps retaining all the sourcenodes/frames *after* all the refs to the streams are gone).

It also applies so hacks to strip out the data from the source before passing it to the minifier. This speeds up the minification massively and also reduces the memory usage to be negligible.