### PR TITLE
do not abort on process exit code

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,18 +88,12 @@ class ClinicBubbleprof extends events.EventEmitter {
       /* istanbul ignore next: windows hack */
       if (code === 3221225786 && os.platform() === 'win32') signal = 'SIGINT'
 
-      // the process did not exit normally
+      // report if the process did not exit normally.
       if (code !== 0 && signal !== 'SIGINT') {
         if (code !== null) {
-          return callback(
-            new Error(`process exited with exit code ${code}`),
-            paths['/']
-          )
+          console.error(`process exited with exit code ${code}`)
         } else {
-          return callback(
-            new Error(`process exited by signal ${signal}`),
-            paths['/']
-          )
+          console.error(`process exited by signal ${signal}`)
         }
       }
 

--- a/test/cmd-collect-exit.test.js
+++ b/test/cmd-collect-exit.test.js
@@ -32,27 +32,10 @@ testNotWindows('cmd - collect - external SIGINT is relayed', function (t) {
   })
 })
 
-test('cmd - collect - non-success exit code causes error', function (t) {
+test('cmd - collect - non-success exit code should not throw', function (t) {
   const cmd = new CollectAndRead({}, '--expose-gc', '-e', 'process.exit(1)')
-
-  cmd.once('error', function (err) {
-    cmd.cleanup()
-
-    t.strictDeepEqual(err, new Error('process exited with exit code 1'))
-    t.end()
-  })
-})
-
-test('cmd - collect - non-success exit code causes error', function (t) {
-  const cmd = new CollectAndRead(
-    {},
-    '--expose-gc', '-e', 'process.kill(process.pid, "SIGKILL")'
-  )
-
-  cmd.once('error', function (err) {
-    cmd.cleanup()
-
-    t.strictDeepEqual(err, new Error('process exited with exit signal SIGKILL'))
+  cmd.on('error', t.ifError.bind(t))
+  cmd.on('ready', function () {
     t.end()
   })
 })


### PR DESCRIPTION
Related to issue #277  and nearform/node-clinic#73

Do not throw on client application termination.
Only report error and continue processing the traces.

Adjusted handler and updated test that check on error throwing.