### PR TITLE
Fix native stack trace test and remove TIMERWRAP assertion in Node 11

### DIFF
--- a/test/cmd-collect.test.js
+++ b/test/cmd-collect.test.js
@@ -74,10 +74,14 @@ test('collect command produces data files with content', function (t) {
         asyncOperationTypes.push(trackedTraceEvent[0].type)
       }
 
-      // Expect Timeout and TIMERWRAP to be there
+      const majorVersion = parseInt(process.version.match(/^v(\d+)\./)[1], 10)
+      // Expect Timeout and TIMERWRAP to be there in Node 10.x and below
+      const oldExpected = ['TIMERWRAP', 'Timeout']
+      // TIMERWRAP was removed in Node 11: https://github.com/nodejs/node/pull/20894
+      const newExpected = ['Timeout']
       t.strictDeepEqual(
         asyncOperationTypes.sort(),
-        ['TIMERWRAP', 'Timeout']
+        majorVersion >= 11 ? newExpected : oldExpected
       )
 
       t.end()

--- a/test/collect-stack-trace.test.js
+++ b/test/collect-stack-trace.test.js
@@ -104,7 +104,23 @@ test('stack trace - native', function (t) {
     frames = stackTrace()
   })
 
-  t.strictDeepEqual(Object.assign({}, frames[1]), {
+  const v8VersionParts = process.versions.v8.split('.')
+  const isTorqueSortVersion = parseInt(v8VersionParts[0], 10) >= 7
+
+  const expectedTorque = {
+    functionName: 'sort',
+    typeName: 'Array',
+    isEval: false,
+    isConstructor: false,
+    isNative: false,
+    isToplevel: false,
+    evalOrigin: '',
+    fileName: '',
+    lineNumber: 0,
+    columnNumber: 0
+  }
+
+  const expectedNative = {
     functionName: 'sort',
     typeName: '',
     isEval: false,
@@ -115,7 +131,12 @@ test('stack trace - native', function (t) {
     fileName: 'native array.js',
     lineNumber: 1,
     columnNumber: 1
-  })
+  }
+
+  t.strictDeepEqual(
+    Object.assign({}, frames[1]),
+    isTorqueSortVersion ? expectedTorque : expectedNative
+  )
 
   t.end()
 })


### PR DESCRIPTION
In v8 7.0, Array.sort() was moved from a JS-based implementation to
Torque:
https://github.com/v8/v8/commit/fa11e2ac0380948a2f57963e6651402c3ca07d04

This means Array.sort() isn't in v8's `array.js` file anymore.
Apparently the goal is to eventually move all or most JS implementations
of builtins like Array to to Torque, so 'native' is a shrinking
category. We may need to do something to detect those Torque things?