### PR TITLE
Ensure stack frames box is closed on navigation down

### DIFF
--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -232,6 +232,8 @@ class BubbleprofUI extends EventEmitter {
   selectNode (layoutNode, animationQueue) {
     const dataNode = layoutNode.node
     const sameNode = this.selectedDataNode && this.selectedDataNode.uid === dataNode.uid
+    this.outputFrames(null) // Make sure no frames are being output, without changing selection
+
     this.svgNodeDiagram.svgNodes.get(layoutNode.id).select()
 
     switch (dataNode.constructor.name) {

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -234,7 +234,7 @@ class BubbleprofUI extends EventEmitter {
     const sameNode = this.selectedDataNode && this.selectedDataNode.uid === dataNode.uid
     this.outputFrames(null) // Make sure no frames are being output, without changing selection
 
-    this.svgNodeDiagram.svgNodes.get(layoutNode.id).select()
+    this.svgNodeDiagram.selectNodeById(layoutNode.id)
 
     switch (dataNode.constructor.name) {
       case 'ShortcutNode':

--- a/visualizer/draw/svg-node-diagram.js
+++ b/visualizer/draw/svg-node-diagram.js
@@ -94,6 +94,10 @@ class SvgNodeDiagram {
     })
   }
 
+  selectNodeById (id) {
+    this.svgNodes.get(id).select()
+  }
+
   deselectAll () {
     this.svgNodes.forEach(svgNode => svgNode.deselect())
   }


### PR DESCRIPTION
Fixes https://github.com/nearform/node-clinic-bubbleprof/issues/229

Before: click into any of the nodes, the stack frame box stays open.

https://upload.clinicjs.org/public/122cca4d0eb5c55898e25a9789209aadbd88cd2dfbfa622a315c38e9a7e27495/10456.clinic-bubbleprof.html#c1

After: click into any of the nodes, and the stack from box closes

https://upload.clinicjs.org/public/c1e73724bf11c2ec8d9f1c751e5152e9a70036a5ee54e2d6a513790071a016c1/10456.clinic-bubbleprof.html#c1