### PR TITLE
unlink socket before listen() if it exists.

### DIFF
--- a/test/integration-servers.test.js
+++ b/test/integration-servers.test.js
@@ -30,7 +30,7 @@ function runServer (name, callback) {
   })
 }
 
-test('basis server aggregates HTTPPARSER', function (t) {
+test('basic server aggregates HTTPPARSER', function (t) {
   runServer('basic', function (err, nodes) {
     if (err) return t.ifError(err)
 

--- a/test/servers/basic.js
+++ b/test/servers/basic.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const fs = require('fs')
 const path = require('path')
 const http = require('http')
 const xsock = require('cross-platform-sock')
@@ -14,4 +15,5 @@ const server = http.createServer(function (req, res) {
   }
 })
 
+try { fs.unlinkSync(sock) } catch (err) {}
 server.listen(sock)

--- a/test/servers/basic.js
+++ b/test/servers/basic.js
@@ -15,5 +15,11 @@ const server = http.createServer(function (req, res) {
   }
 })
 
-try { fs.unlinkSync(sock) } catch (err) {}
+try {
+  fs.unlinkSync(sock)
+} catch (err) {
+  if (err.code !== 'ENOENT') {
+    console.error('could not unlink test-server.sock:', err.stack)
+  }
+}
 server.listen(sock)

--- a/test/servers/express.js
+++ b/test/servers/express.js
@@ -8,7 +8,13 @@ const xsock = require('cross-platform-sock')
 const sock = xsock(path.join(__dirname, '../test-server.sock'))
 const app = express()
 
-try { fs.unlinkSync(sock) } catch (err) {}
+try {
+  fs.unlinkSync(sock)
+} catch (err) {
+  if (err.code !== 'ENOENT') {
+    console.error('could not unlink test-server.sock:', err.stack)
+  }
+}
 const server = app.listen(sock)
 
 let connections = 0

--- a/test/servers/express.js
+++ b/test/servers/express.js
@@ -1,11 +1,14 @@
 'use strict'
 
+const fs = require('fs')
 const path = require('path')
 const express = require('express')
 const xsock = require('cross-platform-sock')
 
 const sock = xsock(path.join(__dirname, '../test-server.sock'))
 const app = express()
+
+try { fs.unlinkSync(sock) } catch (err) {}
 const server = app.listen(sock)
 
 let connections = 0

--- a/test/servers/external.js
+++ b/test/servers/external.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const fs = require('fs')
 const http = require('http')
 const path = require('path')
 const async = require('async')
@@ -23,4 +24,5 @@ const server = http.createServer(function (req, res) {
   }
 })
 
+try { fs.unlinkSync(sock) } catch (err) {}
 server.listen(sock)

--- a/test/servers/external.js
+++ b/test/servers/external.js
@@ -24,5 +24,11 @@ const server = http.createServer(function (req, res) {
   }
 })
 
-try { fs.unlinkSync(sock) } catch (err) {}
+try {
+  fs.unlinkSync(sock)
+} catch (err) {
+  if (err.code !== 'ENOENT') {
+    console.error('could not unlink test-server.sock:', err.stack)
+  }
+}
 server.listen(sock)

--- a/test/servers/latency.js
+++ b/test/servers/latency.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const fs = require('fs')
 const path = require('path')
 const http = require('http')
 const xsock = require('cross-platform-sock')
@@ -16,4 +17,5 @@ const server = http.createServer(function (req, res) {
   }
 })
 
+try { fs.unlinkSync(sock) } catch (err) {}
 server.listen(sock)

--- a/test/servers/latency.js
+++ b/test/servers/latency.js
@@ -17,5 +17,11 @@ const server = http.createServer(function (req, res) {
   }
 })
 
-try { fs.unlinkSync(sock) } catch (err) {}
+try {
+  fs.unlinkSync(sock)
+} catch (err) {
+  if (err.code !== 'ENOENT') {
+    console.error('could not unlink test-server.sock:', err.stack)
+  }
+}
 server.listen(sock)

--- a/test/servers/quine.js
+++ b/test/servers/quine.js
@@ -19,4 +19,5 @@ const server = http.createServer(function request (req, res) {
   })
 })
 
+try { fs.unlinkSync(sock) } catch (err) {}
 server.listen(sock)

--- a/test/servers/quine.js
+++ b/test/servers/quine.js
@@ -19,5 +19,11 @@ const server = http.createServer(function request (req, res) {
   })
 })
 
-try { fs.unlinkSync(sock) } catch (err) {}
+try {
+  fs.unlinkSync(sock)
+} catch (err) {
+  if (err.code !== 'ENOENT') {
+    console.error('could not unlink test-server.sock:', err.stack)
+  }
+}
 server.listen(sock)


### PR DESCRIPTION
this may :pray: address the citgm failure. I still can't reproduce it locally, this is somewhat of a brute force approach.

@mcollina i think you mentioned you could run things in citgm environment? it would be interesting to see if this works there before we fully re enable it if possible…this error happened in at least Ubuntu 14.04 and 18.04