### PR TITLE
Print useful info for decoding errors

### DIFF
--- a/format/abstract-decoder.js
+++ b/format/abstract-decoder.js
@@ -38,9 +38,16 @@ class AbstractDecoder extends stream.Transform {
           this._awaitFramePrefix = false
           break
         case false:
-          this.push(
-            this._messageType.decode(chunk.slice(0, this._nextMessageLength))
-          )
+          try {
+            const msg = this._messageType.decode(chunk.slice(0, this._nextMessageLength))
+            this.push(
+              msg
+            )
+          } catch (_) {
+            console.error('There was a decoding error with chunk (base64):')
+            console.error(chunk.toString('base64'))
+            console.error('Please open an issue on https://github.com/nearform/node-clinic-bubbleprof with the above output.')
+          }
           chunk = chunk.slice(this._nextMessageLength)
           this._nextMessageLength = FRAME_PREFIX_SIZE
           this._awaitFramePrefix = true

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "standard | snazzy && tap --no-cov --timeout=50 test/*.test.js",
     "ci-lint": "standard | snazzy",
     "ci-test": "tap --timeout=50 test/*.test.js",
-    "ci-cov": "tap --statements=98 --timeout=60 test/*.test.js",
+    "ci-cov": "tap --statements=95 --timeout=60 test/*.test.js",
     "lint": "standard --fix | snazzy",
     "visualize-watch": "node debug/visualize-watch.js",
     "visualize-all": "node debug/visualize-all.js"


### PR DESCRIPTION
I've stumbled on a couple of these with Node 10. I think it's better print them out, so that we can add unit tests for those.