### PR TITLE
Remove some performance bottlenecks from very large layouts

### DIFF
--- a/test/visualizer-validation.test.js
+++ b/test/visualizer-validation.test.js
@@ -7,7 +7,8 @@ const {
   validateKey,
   validateNumber,
   uniqueMapKey,
-  uniqueObjectKey
+  uniqueObjectKey,
+  removeFromCounter
 } = require('../visualizer/validation.js')
 
 test('Visualizer validation - isNumber', function (t) {
@@ -90,6 +91,20 @@ test('Visualizer validation - uniqueMapKey', function (t) {
 
   testMap.set(uniqueMapKey('a', testMap), 7)
   t.equals(uniqueMapKey('a', testMap), 'a_3')
+
+  testMap.set(uniqueMapKey('a', testMap), true)
+  testMap.set(uniqueMapKey('a', testMap), true)
+  testMap.set(uniqueMapKey('a', testMap), true)
+  t.ok(testMap.has('a_5'))
+  t.notOk(testMap.has('a_6'))
+
+
+  testMap.delete('a_3')
+  removeFromCounter('a_3', testMap, 'a', '_')
+  t.equals(uniqueMapKey('a', testMap), 'a_3')
+  testMap.set(uniqueMapKey('a', testMap), true)
+  t.equals(uniqueMapKey('a', testMap), 'a_6')
+
   t.end()
 })
 

--- a/test/visualizer-validation.test.js
+++ b/test/visualizer-validation.test.js
@@ -76,8 +76,8 @@ test('Visualizer validation - uniqueMapKey', function (t) {
   t.equals(uniqueMapKey('a', testMap), 'a_1')
   t.equals(uniqueMapKey('b', testMap), 'b_2')
   t.equals(uniqueMapKey(99, testMap), '99_1')
-  t.equals(uniqueMapKey(objectKey, testMap), '[object Object]_1')
   t.equals(uniqueMapKey(objectKey2, testMap), objectKey2)
+  t.equals(uniqueMapKey(objectKey, testMap), '[object Object]_1')
 
   t.equals(uniqueMapKey('a', testMap, '', 1), 'a1')
   t.equals(uniqueMapKey('b', testMap, '_', 1), 'b_2')

--- a/test/visualizer-validation.test.js
+++ b/test/visualizer-validation.test.js
@@ -98,7 +98,6 @@ test('Visualizer validation - uniqueMapKey', function (t) {
   t.ok(testMap.has('a_5'))
   t.notOk(testMap.has('a_6'))
 
-
   testMap.delete('a_3')
   removeFromCounter('a_3', testMap, 'a', '_')
   t.equals(uniqueMapKey('a', testMap), 'a_3')

--- a/visualizer/layout/collapsed-layout.js
+++ b/visualizer/layout/collapsed-layout.js
@@ -7,7 +7,7 @@ const _ = {
 const { ShortcutNode } = require('../data/data-node.js')
 const { LayoutNode, CollapsedLayoutNode } = require('./layout-node.js')
 const { pickLeavesByLongest } = require('./stems.js')
-const { uniqueMapKey } = require('../validation.js')
+const { uniqueMapKey, removeFromCounter } = require('../validation.js')
 
 class CollapsedLayout {
   constructor (layout) {
@@ -246,6 +246,10 @@ class CollapsedLayout {
     this.layoutNodes.delete(squashNode.id)
 
     return collapsed
+  }
+  removeLayoutNode (id) {
+    this.layoutNodes.delete(id)
+    if (id.charAt(0) === 'x') removeFromCounter(id, 'x', this.layoutNodes, '')
   }
   countNonShortcutNodes () {
     const total = this.layoutNodes.size

--- a/visualizer/layout/collapsed-layout.js
+++ b/visualizer/layout/collapsed-layout.js
@@ -54,49 +54,54 @@ class CollapsedLayout {
   setCollapseThreshold (settings, multiplier = 1) {
     // Set an initial value based on settings then test it
     this.collapseThreshold = settings.initialCollapseThreshold * multiplier
+
+    const leaves = pickLeavesByLongest(this.layoutNodes)
+    const leavesCount = leaves.length
+    for (var i = 0; i < leavesCount; i++) {
+      this.testStemLength(leaves[i], settings, multiplier)
+    }
+  }
+  testStemLength (layoutNode, settings, multiplier) {
+    let isCollapsible
     const availableHeight = settings.sizeIndependentHeight
 
-    pickLeavesByLongest(this.layoutNodes).forEach(layoutNode => {
-      let isCollapsible
+    // Begin loop if this stem's absolute total doesn't fit in the available space
+    let absoluteExceedsHeight = layoutNode.stem.lengths.absolute > availableHeight
+    while (absoluteExceedsHeight) {
+      // Loop increases collapse threshold until this stem fits
+      const ancestorIds = layoutNode.stem.ancestors.ids
+      let stemLengthAfterCollapse = 0
 
-      // Begin loop if this stem's absolute total doesn't fit in the available space
-      let absoluteExceedsHeight = layoutNode.stem.lengths.absolute > availableHeight
-      while (absoluteExceedsHeight) {
-        // Loop increases collapse threshold until this stem fits
-        const ancestorIds = layoutNode.stem.ancestors.ids
-        let stemLengthAfterCollapse = 0
-
-        // This should be impossible - but in case some bug is introduced, a warning and break is better than an infinite loop
-        /* istanbul ignore next */
-        if (this.collapseThreshold / multiplier > availableHeight) {
-          const details = `LayoutNode ${layoutNode.id}'s ${ancestorIds.length}-length stem won't collapse to fit ${availableHeight}px.`
-          console.warn(`Infinite loop prevented. ${details}`)
-          break
-        }
-
-        // Iterate backwards through ancestors i.e. from furthest ancestor first
-        for (let i = layoutNode.stem.ancestors.ids.length - 1; i >= 0; i--) {
-          const ancestorNode = this.layoutNodes.get(layoutNode.stem.ancestors.ids[i])
-
-          const childNode = this.layoutNodes.get(layoutNode.stem.ancestors.ids[i + 1])
-          const isMidpoint = childNode && !this.topLayoutNodes.has(ancestorNode)
-          if (!isMidpoint) continue
-
-          isCollapsible = this.isVerticallyCollapsible(childNode, ancestorNode)
-          if (isCollapsible === 'abort') break
-          if (!isCollapsible) {
-            stemLengthAfterCollapse += 1
-          }
-        }
-        if (isCollapsible === 'abort') break // Exit while loop too if it's not possible to collapse any further
-
-        const stemAbsoluteAfterCollapse = layoutNode.stem.getAbsoluteLength(stemLengthAfterCollapse)
-
-        // If this stem's absolute total still doesn't fit, increase the collapse threshold and loop until it does; else exit loop
-        absoluteExceedsHeight = stemAbsoluteAfterCollapse > settings.sizeIndependentHeight
-        if (absoluteExceedsHeight) this.collapseThreshold = this.collapseThreshold * 1.05
+      // This should be impossible - but in case some bug is introduced, a warning and break is better than an infinite loop
+      /* istanbul ignore next */
+      if (this.collapseThreshold / multiplier > availableHeight) {
+        const details = `LayoutNode ${layoutNode.id}'s ${ancestorIds.length}-length stem won't collapse to fit ${availableHeight}px.`
+        console.warn(`Infinite loop prevented. ${details}`)
+        break
       }
-    })
+
+      // Iterate backwards through ancestors i.e. from furthest ancestor first
+      for (let i = layoutNode.stem.ancestors.ids.length - 1; i >= 0; i--) {
+        const ancestorNode = this.layoutNodes.get(layoutNode.stem.ancestors.ids[i])
+
+        const childNode = this.layoutNodes.get(layoutNode.stem.ancestors.ids[i + 1])
+        const isMidpoint = childNode && !this.topLayoutNodes.has(ancestorNode)
+        if (!isMidpoint) continue
+
+        isCollapsible = this.isVerticallyCollapsible(childNode, ancestorNode)
+        if (isCollapsible === 'abort') break
+        if (!isCollapsible) {
+          stemLengthAfterCollapse += 1
+        }
+      }
+      if (isCollapsible === 'abort') break // Exit while loop too if it's not possible to collapse any further
+
+      const stemAbsoluteAfterCollapse = layoutNode.stem.getAbsoluteLength(stemLengthAfterCollapse)
+
+      // If this stem's absolute total still doesn't fit, increase the collapse threshold and loop until it does; else exit loop
+      absoluteExceedsHeight = stemAbsoluteAfterCollapse > settings.sizeIndependentHeight
+      if (absoluteExceedsHeight) this.collapseThreshold = this.collapseThreshold * 1.05
+    }
   }
   indexLayoutNode (nodesMap, layoutNode) {
     nodesMap.set(layoutNode.id, layoutNode)

--- a/visualizer/layout/collapsed-layout.js
+++ b/visualizer/layout/collapsed-layout.js
@@ -16,18 +16,21 @@ class CollapsedLayout {
     // TODO: revisit idempotency of this class - mutates each LayoutNode internally
     this.layoutNodes = new Map([...layout.layoutNodes])
 
-    const layoutNodesArray = [...this.layoutNodes.values()]
-    this.shortcutCount = layoutNodesArray.reduce((count, layoutNode) => count + (layoutNode.node.constructor.name === 'ShortcutNode' ? 1 : 0), 0)
-
     this.scale = layout.scale
     this.minimumNodes = 3
 
     // If debugging, expose one pool of ejected node IDs that is added to each time this class is initialized
     if (layout.settings.debugMode && !layout.ejectedLayoutNodeIds) layout.ejectedLayoutNodeIds = []
 
-    // TODO: stop relying on coincidental Map.keys() order (i.e. stuff would break when child occurs before parent)
-    // e.g. we could attach .topNodes or some iterator to Layout instances
-    this.topLayoutNodes = new Set(layoutNodesArray.filter(layoutNode => !layoutNode.parent))
+    const layoutNodesArray = [...this.layoutNodes.values()]
+    const layoutNodesCount = layoutNodesArray.length
+    this.shortcutCount = 0
+    this.topLayoutNodes = new Set()
+    for (let i = 0; i < layoutNodesCount; ++i) {
+      const layoutNode = layoutNodesArray[i]
+      if (layoutNode.node.constructor.name === 'ShortcutNode') this.shortcutCount++
+      if (!layoutNode.parent) this.topLayoutNodes.add(layoutNode)
+    }
 
     this.setCollapseThreshold(layout.settings, this.scale.heightMultiplier)
 

--- a/visualizer/validation.js
+++ b/visualizer/validation.js
@@ -64,7 +64,6 @@ function getUniqueKey (key, obj, test, startingNum, separator) {
 
 function incrementKeyUntilUnique (key, obj, test, counter, separator) {
   const testKey = counter ? ('' + key + separator + counter) : key
-  if (typeof key === 'object') console.log(key, counter, testKey, test(testKey, obj))
   if (test(testKey, obj)) {
     return { testKey, counter }
   }

--- a/visualizer/validation.js
+++ b/visualizer/validation.js
@@ -36,20 +36,28 @@ function validateNumber (num, targetDescription = '', conditions = {}) {
   return num
 }
 
+const mapKeyCounters = {}
 function uniqueMapKey (key, map, separator, startingNum = 0) {
   const test = (key) => !map.has(key)
-  return incrementKeyUntilUnique(key, startingNum, test, separator)
+  const initialCounter = mapKeyCounters[key] || startingNum
+  const { uniqueKey, counter } = incrementKeyUntilUnique(key, initialCounter, test, separator)
+  mapKeyCounters[uniqueKey] = counter
+  return uniqueKey
 }
 
+const objectKeyCounters = {}
 function uniqueObjectKey (key, object, separator, startingNum = 0) {
   const test = (key) => typeof object[key] === 'undefined'
-  return incrementKeyUntilUnique(key, startingNum, test, separator)
+  const initialCounter = objectKeyCounters[key] || startingNum
+  const { uniqueKey, counter } = incrementKeyUntilUnique(key, initialCounter, test, separator)
+  objectKeyCounters[uniqueKey] = counter
+  return uniqueKey
 }
 
-function incrementKeyUntilUnique (key, counter, test, separator = '_', startAt = null) {
-  if (!key && startAt !== null) key = startAt
+function incrementKeyUntilUnique (key, counter, test, separator = '_') {
   const testKey = counter ? `${key}${separator}${counter}` : key
-  return test(testKey) ? testKey : incrementKeyUntilUnique(key, counter + 1, test, separator)
+  if (test(testKey)) return { uniqueKey: testKey, counter }
+  return incrementKeyUntilUnique(key, counter + 1, test, separator)
 }
 
 module.exports = {

--- a/visualizer/validation.js
+++ b/visualizer/validation.js
@@ -50,7 +50,7 @@ function uniqueObjectKey (key, object, separator = '_', startingNum = 0) {
 }
 
 function getUniqueKey (key, obj, test, startingNum, separator) {
-  let countersKeyed = countersByObj.get(obj)
+  let countersKeyed = countersByObj.get(obj) || {}
   if (!countersKeyed) {
     countersKeyed = {}
     countersByObj.set(obj, countersKeyed)
@@ -71,11 +71,20 @@ function incrementKeyUntilUnique (key, obj, test, counter, separator) {
   return incrementKeyUntilUnique(key, obj, test, counter + 1, separator)
 }
 
+function removeFromCounter (id, key, obj, separator = '_') {
+  const countersKeyed = countersByObj.get(obj)
+  if (countersKeyed && typeof countersKeyed[key + separator] === 'number') {
+    const counter = numberiseIfNumericString(id.replace(key + separator, ''))
+    if (isNumber(counter)) countersKeyed[key + separator] = counter - 1
+  }
+}
+
 module.exports = {
   isNumber,
   numberiseIfNumericString,
   validateKey,
   validateNumber,
   uniqueMapKey,
-  uniqueObjectKey
+  uniqueObjectKey,
+  removeFromCounter
 }


### PR DESCRIPTION
This extracts a couple of fixes from some older performance work that became unweildy. It doesn't fix all the performance issues, but it does isolate and fix two important ones while some bugs in the other perf work are being fixed:

 - Some excessive iteration when generating unique key IDs
 - Some repeated logic when checking if the amount of layoutnode collapsing has dropped below threshold

Both of these become problems when there are more than around a thousand nodes in a layout.

Example before (for me, it takes around 27 seconds to open the big 5068-node node):

https://upload.clinicjs.org/public/78eb0733e85ee8e1eec54e3c81bc13aa6ed801ca4b612cb954837e47cd1b4cac/1005.clinic-bubbleprof.html

Example after (for me, it now takes around 4 seconds):

https://upload.clinicjs.org/public/d6c3a2118b4c42a15f3db4849b8702beb84ed75cc2a62495968e3673276dde12/1005.clinic-bubbleprof.html