### PR TITLE
[471] - Add engine property with correct minimum version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "Programmable interface to clinic bubbleprof",
   "repository": "nearform/node-clinic-bubbleprof",
   "version": "1.9.7",
+  "engines": {
+    "node": "^11.0.0 || ^10.0.0 || >=8.11.1"
+  },
   "scripts": {
     "test": "standard | snazzy && tap --no-cov --timeout=50 test/*.test.js",
     "ci-lint": "standard | snazzy",


### PR DESCRIPTION
Updates engine inline with [minimum from docs](https://clinicjs.org/documentation/bubbleprof/setup).