### PR TITLE
Improve performance and tidy up area chart / hover code

### DIFF
--- a/visualizer/draw/area-chart.js
+++ b/visualizer/draw/area-chart.js
@@ -233,6 +233,7 @@ class AreaChart extends HtmlContent {
       .on('mouseout', () => {
         if (this.parentContent.constructor.name === 'HoverBox') return
         this.topmostUI.highlightNode(null)
+        this.ui.highlightColour('type', null)
       })
       .on('click', (d) => {
         const layoutNodeId = extractLayoutNodeId(d.key)

--- a/visualizer/draw/area-chart.js
+++ b/visualizer/draw/area-chart.js
@@ -50,33 +50,30 @@ class AreaChart extends HtmlContent {
       this.initializeFromData()
     })
 
-//    if (this.key !== 'AreaChart-HoverBox') {
-      this.highlightedLayoutNode = null
+    this.highlightedLayoutNode = null
 
-      this.hoverListener = layoutNode => {
-        if (!this.d3AreaPaths || layoutNode === this.highlightedLayoutNode) return
-        this.d3AreaPaths.classed('highlighted', d => layoutNode && extractLayoutNodeId(d.key) === layoutNode.id)
-        this.highlightedLayoutNode = layoutNode
-      }
+    this.hoverListener = layoutNode => {
+      if (!this.d3AreaPaths || layoutNode === this.highlightedLayoutNode) return
+      this.d3AreaPaths.classed('highlighted', d => layoutNode && extractLayoutNodeId(d.key) === layoutNode.id)
+      this.highlightedLayoutNode = layoutNode
+    }
 
-      this.ui.on('setTopmostUI', topmostUI => {
-        if (this.topmostUI === topmostUI) return
-        // Remove listener from old topmostUI
-        this.topmostUI.removeListener('hover', this.hoverListener)
+    this.ui.on('setTopmostUI', topmostUI => {
+      if (this.topmostUI === topmostUI) return
+      // Remove listener from old topmostUI
+      this.topmostUI.removeListener('hover', this.hoverListener)
 
-        // Add listener to new one
-        this.topmostUI = topmostUI
-        this.topmostUI.on('hover', this.hoverListener)
+      // Add listener to new one
+      this.topmostUI = topmostUI
+      this.topmostUI.on('hover', this.hoverListener)
 
-        if (this.key === 'AreaChart-HoverBox') return
+      if (this.key === 'AreaChart-HoverBox') return
 
-        this.createPathsForLayout()
-        this.width = null
-//        this.applyLayoutNode(topmostUI.layoutNode)
-        this.updateWidth()
-        this.draw()
-      })
-//    }
+      this.createPathsForLayout()
+      this.width = null
+      this.updateWidth()
+      this.draw()
+    })
   }
   updateWidth () {
     this.widthToApply = this.key === 'AreaChart-HoverBox' ? 300 : this.d3AreaChartSVG.node().getBoundingClientRect().width

--- a/visualizer/draw/area-chart.js
+++ b/visualizer/draw/area-chart.js
@@ -39,7 +39,12 @@ class AreaChart extends HtmlContent {
       .y1(d => this.yScale(d[1]))
 
     this.ui.on('setData', () => {
-      this.setData()
+      if (!this.d3AreaPaths) {
+        this.setData()
+      } else {
+        this.updateWidth()
+        this.draw()
+      }
     })
     this.ui.on('initializeFromData', () => {
       this.initializeFromData()

--- a/visualizer/draw/hover-box.js
+++ b/visualizer/draw/hover-box.js
@@ -56,6 +56,7 @@ class HoverBox extends HtmlContent {
 
     this.ui.on('hover', layoutNode => {
       if (layoutNode) this.layoutNode = layoutNode
+      if (this.asyncOperationsChart) this.asyncOperationsChart.applyLayoutNode(layoutNode)
       this.changeVisibility(!!layoutNode)
     })
   }
@@ -192,8 +193,6 @@ class HoverBox extends HtmlContent {
     this.d3Element.on('mouseleave', () => {
       this.ui.highlightNode(null)
     })
-
-    this.asyncOperationsChart.applyLayoutNode(layoutNode)
 
     // Ensure off-bottom class is not applied before calculating if it's needed
     this.d3Element.classed('off-bottom', false)

--- a/visualizer/draw/side-bar-drag.js
+++ b/visualizer/draw/side-bar-drag.js
@@ -74,6 +74,7 @@ class SideBarDrag extends HtmlContent {
 
   redrawLayout () {
     this.topMostUI.redrawLayout()
+    this.topMostUI.originalUI.redrawLayout()
     this.showRedrawing(false)
   }
 


### PR DESCRIPTION
This mostly improves the performance of updates and redraws of the area charts, which in turn greatly improves the performance of the hover boxes on large profiles. It also includes a fix for a small bug where hovering over an area chart can result in a colour getting stuck highlighted.
 
For example, **before**, here after opening the big circle (happens automatically on load from hash), on my machine hovering over any node has a very noticeable delay of around four seconds:

https://upload.clinicjs.org/public/3ffbe38013d868abce48123908c28ef10bc4cedb078d09848f51706f47b47dd3/1005.clinic-bubbleprof.html#c3

**After**, it's greatly reduced (maybe up to half a second on my machine):

https://upload.clinicjs.org/public/f447aca7199bb0661f81fbd6d954b58398b70195b7aacb8cd9b2a8b9924300cc/1005.clinic-bubbleprof.html#c3

This is mostly by reducing how often usually-fast but potentially-expensive methods in the area chart are called.