### PR TITLE
Use JS/CSS build scripts and main template from Clinic Common

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,18 +9,17 @@ const { spawn } = require('child_process')
 const analysis = require('./analysis/index.js')
 const browserify = require('browserify')
 const envify = require('loose-envify/custom')
-const streamTemplate = require('stream-template')
 const joinTrace = require('node-trace-log-join')
 const getLoggingPaths = require('@nearform/clinic-common').getLoggingPaths('bubbleprof')
 const SystemInfoDecoder = require('./format/system-info-decoder.js')
 const StackTraceDecoder = require('./format/stack-trace-decoder.js')
 const TraceEventDecoder = require('./format/trace-event-decoder.js')
 const minifyInline = require('./lib/minify-inline')
-
 const { promisify } = require('util')
 const readFile = promisify(require('fs').readFile)
 const postcss = require('postcss')
 const postcssImport = require('postcss-import')
+const mainTemplate = require('@nearform/clinic-common/templates/main')
 
 class ClinicBubbleprof extends events.EventEmitter {
   constructor (settings = {}) {
@@ -184,23 +183,18 @@ class ClinicBubbleprof extends events.EventEmitter {
       })
 
     // build output file
-    const outputFile = streamTemplate`
-      <!DOCTYPE html>
-      <meta charset="utf8">
-      <meta name="viewport" content="width=device-width">
-      <title>Clinic Bubbleprof</title>
-      <link rel="shortcut icon" type="image/png" href="${clinicFaviconBase64}">
-      <style>${styleFile}</style>
-      <div id="banner">
-        <a id="main-logo" href="https://github.com/nearform/node-clinic-bubbleprof" title="Clinic Bubbleprof on GitHub" target="_blank">
-          ${logoFile} <span>Bubbleprof</span>  
-        </a>
-        <a id="company-logo" href="https://nearform.com" title="nearForm" target="_blank">
-          ${nearFormLogoFile}
-        </a>
-      </div>
-      <script>${scriptFile}</script>
-    `
+    const outputFile = mainTemplate({
+      favicon: clinicFaviconBase64,
+      title: 'Clinic Bubbleprof',
+      styles: styleFile,
+      script: scriptFile,
+      headerLogoUrl: 'https://github.com/nearform/node-clinic-bubbleprof',
+      headerLogoTitle: 'Clinic Bubbleprof on GitHub',
+      headerLogo: logoFile,
+      headerText: 'Bubbleprof',
+      nearFormLogo: nearFormLogoFile,
+      uploadId: outputFilename.split('/').pop().split('.html').shift()
+    })
 
     pump(
       outputFile,

--- a/index.js
+++ b/index.js
@@ -7,18 +7,14 @@ const path = require('path')
 const pump = require('pump')
 const { spawn } = require('child_process')
 const analysis = require('./analysis/index.js')
-const browserify = require('browserify')
-const envify = require('loose-envify/custom')
 const joinTrace = require('node-trace-log-join')
 const getLoggingPaths = require('@nearform/clinic-common').getLoggingPaths('bubbleprof')
 const SystemInfoDecoder = require('./format/system-info-decoder.js')
 const StackTraceDecoder = require('./format/stack-trace-decoder.js')
 const TraceEventDecoder = require('./format/trace-event-decoder.js')
 const minifyInline = require('./lib/minify-inline')
-const { promisify } = require('util')
-const readFile = promisify(require('fs').readFile)
-const postcss = require('postcss')
-const postcssImport = require('postcss-import')
+const buildJs = require('@nearform/clinic-common/scripts/build-js')
+const buildCss = require('@nearform/clinic-common/scripts/build-css')
 const mainTemplate = require('@nearform/clinic-common/templates/main')
 
 class ClinicBubbleprof extends events.EventEmitter {
@@ -155,32 +151,22 @@ class ClinicBubbleprof extends events.EventEmitter {
 
     dataFile.on('warning', msg => this.emit('warning', msg))
 
-    // create script-file stream
-    const b = browserify({
-      'basedir': __dirname,
-      'debug': this.debug,
-      'noParse': [fakeDataPath]
-    })
-    b.transform('brfs')
-    b.transform(envify({ DEBUG_MODE: this.debug }))
-    b.require(dataFile, {
-      'file': fakeDataPath
-    })
-    b.add(scriptPath)
-    let scriptFile = b.bundle()
-
-    // create style-file stream
-    const processor = postcss([
-      postcssImport()
-    ])
-    const styleFile = readFile(stylePath, 'utf8')
-      .then((css) => processor.process(css, {
-        from: stylePath,
-        map: this.debug ? { inline: true } : false
-      }))
-      .then((result) => {
-        return result.css
+    // build JS
+    let scriptFile = buildJs({
+      basedir: __dirname,
+      debug: this.debug,
+      fakeDataPath,
+      scriptPath,
+      beforeBundle: b => b.require(dataFile, {
+        file: fakeDataPath
       })
+    })
+
+    // build CSS
+    const styleFile = buildCss({
+      stylePath,
+      debug: this.debug
+    })
 
     // build output file
     const outputFile = mainTemplate({

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "array-flatten": "^2.1.1",
     "async": "^2.5.0",
     "brfs": "^2.0.0",
-    "browserify": "^16.2.2",
     "d3-axis": "^1.0.8",
     "d3-drag": "^1.2.3",
     "d3-ease": "^1.0.3",
@@ -53,11 +52,8 @@
     "mkdirp": "^0.5.1",
     "node-trace-log-join": "^1.0.0",
     "on-net-listen": "^1.0.0",
-    "postcss": "^7.0.6",
-    "postcss-import": "^12.0.1",
     "protocol-buffers": "^4.0.4",
     "pump": "^3.0.0",
-    "stream-template": "0.0.10",
     "terser": "^3.10.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@nearform/trace-events-parser": "^1.0.4",
     "array-flatten": "^2.1.1",
     "async": "^2.5.0",
-    "brfs": "^2.0.0",
     "d3-axis": "^1.0.8",
     "d3-drag": "^1.2.3",
     "d3-ease": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "keywords": [],
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@nearform/clinic-common": "^1.3.1",
+    "@nearform/clinic-common": "^1.5.0",
     "@nearform/trace-events-parser": "^1.0.4",
     "array-flatten": "^2.1.1",
     "async": "^2.5.0",

--- a/visualizer/main.js
+++ b/visualizer/main.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const drawOuterUI = require('./draw/index.js')
+const askBehaviours = require('@nearform/clinic-common/behaviours/ask')
+
+askBehaviours()
 
 // Currently no headless browser testing, only test browser-independent logic
 /* istanbul ignore next */

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -1,5 +1,6 @@
-@import "@nearform/clinic-common/spinner/style.css";
-@import "@nearform/clinic-common/icons/style.css";
+@import '@nearform/clinic-common/styles/styles.css';
+@import '@nearform/clinic-common/spinner/style.css';
+@import '@nearform/clinic-common/icons/style.css';
 @import './draw/frames.css';
 @import './draw/banner.css';
 @import './draw/header.css';
@@ -11,7 +12,7 @@ html {
   --overlay-bg-color: rgba(55, 61, 79, 0.94);
 
   --banner-bg-color: rgb(41, 45, 57);
-  --banner-logo-color: rgba(255, 255, 255, 0.87);
+  --nc-colour-header-background: rgb(41, 45, 57);
 
   --spinner-border-color: var(--cyan-highlight);
 
@@ -75,7 +76,8 @@ html.light-theme {
   --main-bg-translucent: rgba(239, 239, 239, 0.94);
   --overlay-bg-color: rgba(209, 211, 218, 0.94);
 
-  --banner-bg-color: rgb(214, 214, 214);
+  --banner-bg-color: rgb(65, 69, 85);
+  --nc-colour-header-background: rgb(65, 69, 85);
 
   --node-background: rgb(255, 255, 255);
   --highlight-bg-color: rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## Overview
This strips out duplicated build scripts for JS and CSS compilation and uses a template function to import a consistent UI chrome along with necessary styles and behaviours showing a tray with a command to copy when you click the 'Ask an expert' button.

**[Example output](https://upload.clinicjs.org/public/76e375b8e9ade6560a00e012a2815459a7e67b3bbb074d50f4ed3ee7bb338efe/45498.clinic-bubbleprof.html)**

## Screenshots

### Mobile
![image](https://user-images.githubusercontent.com/3594817/51917928-8141ec00-23d8-11e9-8f60-544b218d2c64.png)

![image](https://user-images.githubusercontent.com/3594817/51917937-8606a000-23d8-11e9-9998-fae726ee1ae1.png)

### Desktop
![image](https://user-images.githubusercontent.com/3594817/51917986-9cacf700-23d8-11e9-801e-5a3e9a3641ae.png)

![image](https://user-images.githubusercontent.com/3594817/51917947-8bfc8100-23d8-11e9-9218-ccee099db23e.png)
