### PR TITLE
Detect module name for eval frames

### DIFF
--- a/analysis/stack-trace/frames.js
+++ b/analysis/stack-trace/frames.js
@@ -83,8 +83,17 @@ class Frame {
   }
 
   getModuleName (systemInfo) {
-    const filePath = this.fileName.split(systemInfo.pathSeparator)
-    if (!filePath.includes('node_modules')) return null
+    let filePath = this.fileName.split(systemInfo.pathSeparator)
+    // For eval frames, use the source file listed in the `evalOrigin`
+    if (this.fileName === '' && this.isEval) {
+      const m = this.evalOrigin.match(/\((.*?):\d+:\d+\)$/)
+      if (m) {
+        filePath = m[1].split(systemInfo.pathSeparator)
+      }
+    }
+    if (!filePath.includes('node_modules')) {
+      return null
+    }
 
     // Find the last node_modules directory, and count how many were
     // encountered.

--- a/test/analysis-aggregate-mark-module.test.js
+++ b/test/analysis-aggregate-mark-module.test.js
@@ -50,10 +50,23 @@ test('Aggregate Node - mark module', function (t) {
     type: 'TickObject'
   })
 
+  const aggregateNodeEval = new FakeAggregateNode({
+    aggregateId: 2,
+    parentAggregateId: 1,
+    children: [],
+    frames: [
+      { fileName: '/node_modules/promise/lib/core.js' },
+      { fileName: '', isEval: true, evalOrigin: 'eval at denodeifyWithoutCount (/node_modules/promise/lib/node-extensions.js:90:10)' }
+    ],
+    mark: ['external', null, null],
+    type: 'TickObject'
+  })
+
   const systemInfo = new FakeSystemInfo('/')
   const aggregateNodesInput = [
     aggregateNodeRoot, aggregateNodeNodecore,
-    aggregateNodeInternal, aggregateNodeExternal
+    aggregateNodeInternal, aggregateNodeExternal,
+    aggregateNodeEval
   ]
 
   startpoint(aggregateNodesInput, { objectMode: true })
@@ -75,6 +88,10 @@ test('Aggregate Node - mark module', function (t) {
       t.strictDeepEqual(
         aggregateNodesOutput[3].mark.toJSON(),
         ['external', 'deep', null]
+      )
+      t.strictDeepEqual(
+        aggregateNodesOutput[4].mark.toJSON(),
+        ['external', 'promise', null]
       )
       t.end()
     }))


### PR DESCRIPTION
Fixes #303, where the topmost frame in a stack for an external module was part of an eval() call. When marking aggregate nodes it tried to get the module name of the topmost frame in the module, which would be `null` for eval frames.

eval frames contain a file path in brackets `eval at parentFn (/path.js:X:Y)` inside the `evalOrigin` property, so we can fall back to that.