### PR TITLE
Render area chart as canvas instead of SVG

### DIFF
--- a/debug/visualize-watch.js
+++ b/debug/visualize-watch.js
@@ -3,7 +3,7 @@
 var chokidar = require('chokidar')
 var v = require('./visualize-mod.js')
 
-const debounce = require('lodash.debounce')
+const debounce = require('lodash/debounce')
 
 // this is useful when updating multiple files in just one go (i.e. checking-out a branch)
 const debVisualize = debounce(v.visualize, 100)

--- a/visualizer/draw/area-chart.js
+++ b/visualizer/draw/area-chart.js
@@ -328,7 +328,7 @@ class AreaChart extends HtmlContent {
       .attr('class', 'area')
       .attr('cssId', d => `type-${d.key.split('_')[0]}`)
       .attr('isEven', d => !(d.index % 2))
-      .attr('isFiltered', d => (d.key.split('_')[1] === 'absent' || (this.layoutNode && this.layoutNode.id !== extractLayoutNodeId(d.key))))
+      .attr('isFiltered', d => !!(d.key.split('_')[1] === 'absent' || (this.layoutNode && this.layoutNode.id !== extractLayoutNodeId(d.key))))
   }
 
   applyLayoutNode (layoutNode = null) {
@@ -457,7 +457,6 @@ class AreaChart extends HtmlContent {
     if (this.layoutNodeToApply) {
       this.layoutNode = this.layoutNodeToApply
       this.layoutNodeToApply = null
-      // this.drawFiltering()
       this.drawToCanvas(true)
     }
     if (this.widthToApply && this.widthToApply !== this.width) {
@@ -472,7 +471,7 @@ class AreaChart extends HtmlContent {
     this.dataContainer.selectAll('custom.area').each((d, i, nodes) => {
       const node = d3.select(nodes[i])
       const { fillColour, opacity, blendMode } = this.getCanvasAreaStyles(node.attr('cssId'), node.attr('isEven'), filtered && node.attr('isFiltered'))
-      this.canvasContext.globaleCompositeOperation = blendMode
+      this.canvasContext.globalCompositeOperation = blendMode
       this.canvasContext.globalAlpha = opacity
       this.canvasContext.beginPath()
       this.areaMaker.context(this.canvasContext)(d)

--- a/visualizer/draw/area-chart.js
+++ b/visualizer/draw/area-chart.js
@@ -499,6 +499,7 @@ class AreaChart extends HtmlContent {
     d3Col.opacity = opacity
     this.canvasContext.beginPath()
     this.areaMaker.context(this.canvasContext)(d)
+    // Reset area's colour, so repeated hover in/out doesn't overlay colours increasing their intensity
     this.canvasContext.fillStyle = this.getCSSVarValue('--main-bg-color')
     this.canvasContext.fill()
     this.canvasContext.fillStyle = d3Col.toString()

--- a/visualizer/draw/area-chart.js
+++ b/visualizer/draw/area-chart.js
@@ -255,7 +255,10 @@ class AreaChart extends HtmlContent {
           this.showSlice(d3.event)
           const d = this.getCurrentMouseNode(d3.event)
           this.d3AreaChartSVG.style('cursor', d ? 'pointer' : 'default')
-          if (!d) return
+          if (!d) {
+            if (!this.isInHoverBox) this.topmostUI.highlightNode(null)
+            return
+          }
           const layoutNodeId = extractLayoutNodeId(d.key)
           if (!layoutNodeId || this.isInHoverBox) return
           const layoutNode = this.topmostUI.layout.layoutNodes.get(layoutNodeId)

--- a/visualizer/draw/area-chart.js
+++ b/visualizer/draw/area-chart.js
@@ -255,6 +255,7 @@ class AreaChart extends HtmlContent {
           this.showSlice(d3.event)
           const d = this.getCurrentMouseNode(d3.event)
           if (!d) return
+          document.body.style.cursor = 'pointer'
           const layoutNodeId = extractLayoutNodeId(d.key)
           if (!layoutNodeId || this.isInHoverBox) return
           const layoutNode = this.topmostUI.layout.layoutNodes.get(layoutNodeId)
@@ -264,6 +265,7 @@ class AreaChart extends HtmlContent {
           this.ui.highlightColour('type', d.key.split('_')[0])
         })
         .on('mouseout', () => {
+          document.body.style.cursor = 'default'
           if (this.isInHoverBox) return
           this.topmostUI.highlightNode(null)
           this.ui.highlightColour('type', null)

--- a/visualizer/draw/area-chart.js
+++ b/visualizer/draw/area-chart.js
@@ -254,8 +254,8 @@ class AreaChart extends HtmlContent {
         .on('mousemove', () => {
           this.showSlice(d3.event)
           const d = this.getCurrentMouseNode(d3.event)
+          this.d3AreaChartSVG.style('cursor', d ? 'pointer' : 'default')
           if (!d) return
-          document.body.style.cursor = 'pointer'
           const layoutNodeId = extractLayoutNodeId(d.key)
           if (!layoutNodeId || this.isInHoverBox) return
           const layoutNode = this.topmostUI.layout.layoutNodes.get(layoutNodeId)
@@ -265,7 +265,7 @@ class AreaChart extends HtmlContent {
           this.ui.highlightColour('type', d.key.split('_')[0])
         })
         .on('mouseout', () => {
-          document.body.style.cursor = 'default'
+          this.d3AreaChartSVG.style('cursor', 'default')
           if (this.isInHoverBox) return
           this.topmostUI.highlightNode(null)
           this.ui.highlightColour('type', null)

--- a/visualizer/draw/d3-subset.js
+++ b/visualizer/draw/d3-subset.js
@@ -32,7 +32,8 @@ const d3 = Object.assign(
   // d3.timeSecond
   require('d3-time'),
   // d3.selection().transition()
-  require('d3-transition')
+  require('d3-transition'),
+  require('d3-color')
 )
 
 // This property changes after importing so we fake a live binding.

--- a/visualizer/style.css
+++ b/visualizer/style.css
@@ -931,54 +931,6 @@ body[data-highlight-type='other'] #node-link svg:not(:hover) .type-other {
   border-color: var(--type-colour-5);
 }
 
-/* In area chart specifically, apply to fill instead of stroke */
-
-svg.area-chart-svg .area-path {
-  stroke: none;
-  opacity: 0.8;
-}
-svg.area-chart-svg .area-path:not(.filtered) {
-  cursor: pointer;
-}
-
-svg.area-chart-svg .area-path-even {
-  opacity: 0.6;
-}
-svg.area-chart-svg .area-path.highlighted {
-  mix-blend-mode: screen;
-  opacity: 1;
-}
-svg.area-chart-svg .area-path.type-files-streams {
-  fill: var(--type-colour-1);
-}
-svg.area-chart-svg .area-path.type-networks {
-  fill: var(--type-colour-2);
-}
-svg.area-chart-svg .area-path.type-crypto {
-  fill: var(--type-colour-3);
-}
-svg.area-chart-svg .area-path.type-timing-promises {
-  fill: var(--type-colour-4);
-}
-svg.area-chart-svg .area-path.type-other {
-  fill: var(--type-colour-5);
-}
-svg.area-chart-svg .area-path.not-emphasised {
-  opacity: 0.45;
-}
-svg.area-chart-svg .area-path.filtered {
-  opacity: 0.14;
-}
-#side-bar svg.area-chart-svg .area-path.filtered {
-  animation-name: mostly-fade-out;
-}
-
-@keyframes mostly-fade-out {
-  to {
-    opacity: 0.14;
-  }
-}
-
 .hover-box .area-chart {
   background: var(--reverse-contrast);
   opacity: 1;


### PR DESCRIPTION
Canvas should be a better performer than SVG when there are more than 1000 node points to render. 

This PR migrates rendering to  canvas of the Area Chart that appears on the right hand column, and the hover-panel in the main layout.

The approach taken was to
- maintain SVG for the supporting chart data - axes, and the slice indicator
- create a custom D3 element to offer some separation between generic data manipulation and the draw to canvas
- introduce a the canvas element and position it in the chart area
- add a hidden colour mapping canvas element for tracking mouse activity (as rendered elements are not available to event handlers the way they are available to SVG nodes)

### bugs remaining - and being picked up
- [x] just noticed some nuance in the SVG colours are lost - will take a look at adjusting   (looks like blendmode)
- [x] problem with the highlight state of the hovered  - not rendereing brighter as it should


For comparison: 


before:
![image](https://user-images.githubusercontent.com/395101/53958145-2b97e800-40d8-11e9-94b6-65c6fe4118dc.png)

 

after: 

![image](https://user-images.githubusercontent.com/395101/53958083-1458fa80-40d8-11e9-85b2-0e491e758364.png)



