### PR TITLE
More specific userland names for node clusters

### DIFF
--- a/analysis/aggregate/name-aggregate-nodes.js
+++ b/analysis/aggregate/name-aggregate-nodes.js
@@ -28,7 +28,10 @@ function getAggregateName (aggregateNode, sysInfo) {
     'module.exports',
     'handler',
     'async.series',
-    'async.parallel'
+    'async.parallel',
+    'Promise.all.then',
+    'Promise.all',
+    'Object'
   ]
   if (userland.length) {
     const uniqueNameOptions = [...new Set(userland.map(frame => name(frame)))]

--- a/analysis/aggregate/name-aggregate-nodes.js
+++ b/analysis/aggregate/name-aggregate-nodes.js
@@ -38,11 +38,12 @@ function getAggregateName (aggregateNode, sysInfo) {
     let nameCandidate = uniqueNameOptions.reduce((prev, curr) => !tooGeneric.includes(curr) ? curr : prev, null)
 
     if (!nameCandidate) {
+      const sysPath = sysInfo.pathSeparator.includes('\\') ? path.win32 : path
       let filePath = userland[0].getFileNameWithoutModuleDirectory(sysInfo)
-      nameCandidate = path.basename(filePath)
+      nameCandidate = sysPath.basename(filePath)
       // we don't want a default name - let's take the containing dirname
       if (nameCandidate === 'index.js') {
-        nameCandidate = path.dirname(filePath).split(sysInfo.pathSeparator).pop()
+        nameCandidate = sysPath.dirname(filePath).split(sysInfo.pathSeparator).pop()
       }
     }
     return nameCandidate

--- a/analysis/barrier/name-barrier-nodes.js
+++ b/analysis/barrier/name-barrier-nodes.js
@@ -124,7 +124,9 @@ class NameBarrierNodes extends stream.Transform {
     const moduleNames = getModuleNames(aggregateNode, this.systemInfo)
     const typeName = toName(types)
     const prefix = moduleNames.length > 3 ? '... > ' : ''
-
+    // http is special for identifying latency etc - so we don't let http names be overwritten by userland or module filenames
+    // - see: https://github.com/nearform/node-clinic-bubbleprof/pull/115 and existing integration tests
+    if (typeName.includes('http')) return typeName
     if (moduleNames.length) return prefix + moduleNames.slice(-3).join(' > ')
     return typeName
   }
@@ -168,7 +170,8 @@ function getModuleNames (aggregateNode, sysInfo) {
       .filter(noDups())
   }
   // it's not external - return the userland name
-  return [aggregateNode.name]
+  if (aggregateNode.name) return [aggregateNode.name]
+  return []
 }
 
 function isExternal (frames, sysInfo) {

--- a/analysis/barrier/name-barrier-nodes.js
+++ b/analysis/barrier/name-barrier-nodes.js
@@ -155,7 +155,6 @@ function noDups () {
 
 function getModuleNames (aggregateNode, sysInfo) {
   const frames = aggregateNode.frames.filter(frame => frame.fileName)
-
   if (isExternal(frames, sysInfo)) {
     const modules = aggregateNode.frames
       .filter((frame) => !frame.isNodecore(sysInfo))
@@ -168,8 +167,8 @@ function getModuleNames (aggregateNode, sysInfo) {
       .filter(name => name)
       .filter(noDups())
   }
-
-  return []
+  // it's not external - return the userland name
+  return [aggregateNode.name]
 }
 
 function isExternal (frames, sysInfo) {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "test": "standard | snazzy && tap --no-cov --timeout=50 test/*.test.js",
+    "test:file": "standard | snazzy && tap --no-cov --timeout=50",
     "ci-lint": "standard | snazzy",
     "ci-test": "tap --timeout=50 test/*.test.js",
     "ci-cov": "tap --statements=95 --timeout=60 test/*.test.js",


### PR DESCRIPTION
[Trello: Update clusterNode names to better indicate contents](https://trello.com/c/YXWvSKCE/733-3-update-clusternode-names-to-better-indicate-contents)

This looks to improve the labelling  for userland information in clusterNodes - we can extract better information from the AggregateNode Frames when the initial label is too generic - and pass that up to the ClusterNode. 

From the example in the above Trello Issue: 

Before: 
![image](https://user-images.githubusercontent.com/395101/54288615-ad3bba00-459f-11e9-802d-5899c6b26937.png)

After: 
![image](https://user-images.githubusercontent.com/395101/54288558-95643600-459f-11e9-9214-d5894a3b514c.png)
 
Some other generic labelling _may_ be more valuable in places where the `type` is displayed (e.g. `nextTick` - here is an example where the more specific information may or may not be of value. Should we refine these rules?

![image](https://user-images.githubusercontent.com/395101/54288320-30a8db80-459f-11e9-8a52-6b287ba75dd5.png)
