### PR TITLE
WIP: New canvas render methods for node layout

### DIFF
--- a/visualizer/draw/area-chart.js
+++ b/visualizer/draw/area-chart.js
@@ -2,6 +2,8 @@
 
 const d3 = require('./d3-subset.js')
 const HtmlContent = require('./html-content.js')
+const getCSSVarValue = require('./util/getCssVarValue.js')
+
 const {
   numberiseIfNumericString,
   uniqueObjectKey
@@ -19,7 +21,7 @@ class AreaChart extends HtmlContent {
       }
     }, contentProperties))
 
-    this.cssVarValues = {}
+    this.cssVarValues = getCSSVarValue()
 
     this.initialized = false
     this.topmostUI = this.ui
@@ -82,17 +84,6 @@ class AreaChart extends HtmlContent {
   }
 
   /**
-   * Get the value of a CSS variable
-   * @param {String} varName
-   */
-  getCSSVarValue (varName) {
-    if (!this.cssVarValues[varName]) {
-      this.cssVarValues[varName] = window.getComputedStyle(document.body).getPropertyValue(varName)
-    }
-    return this.cssVarValues[varName]
-  }
-
-  /**
    * Generic function to define the styles for the canvas based visualization
    * For SVG we could do this with CSS - but for Canvas we don't have access to CSS
    */
@@ -105,7 +96,7 @@ class AreaChart extends HtmlContent {
       'type-other': '--type-colour-5'
     }
 
-    const fillColour = this.getCSSVarValue(colourIds[type] || 'type-other')
+    const fillColour = this.cssVarValues(colourIds[type] || 'type-other')
     let opacity = 0.8
     if (isEven) opacity = 0.6
     if (isHighlighted) opacity = 1
@@ -500,7 +491,7 @@ class AreaChart extends HtmlContent {
     this.canvasContext.beginPath()
     this.areaMaker.context(this.canvasContext)(d)
     // Reset area's colour, so repeated hover in/out doesn't overlay colours increasing their intensity
-    this.canvasContext.fillStyle = this.getCSSVarValue('--main-bg-color')
+    this.canvasContext.fillStyle = this.cssVarValues('--main-bg-color')
     this.canvasContext.fill()
     this.canvasContext.fillStyle = d3Col.toString()
     this.canvasContext.fill()

--- a/visualizer/draw/bubble-node-container.js
+++ b/visualizer/draw/bubble-node-container.js
@@ -1,13 +1,14 @@
 'use strict'
 
 const HtmlContent = require('./html-content.js')
-const SvgNodeDiagram = require('./svg-node-diagram.js')
+const BubbleNodeDiagram = require('./bubble-node-diagram.js')
 
-class SvgContainer extends HtmlContent {
+class BubbleNodeContainer extends HtmlContent {
   constructor (parentContent, contentProperties = {}) {
     const defaultProperties = {
       htmlElementType: 'svg'
     }
+    console.log(contentProperties)
     super(parentContent, Object.assign(defaultProperties, contentProperties))
 
     if (contentProperties.svgBounds) {
@@ -22,7 +23,7 @@ class SvgContainer extends HtmlContent {
       this.svgBounds = Object.assign(defaultBounds, contentProperties.svgBounds)
     }
 
-    this.svgNodeDiagram = new SvgNodeDiagram(this)
+    this.svgNodeDiagram = new BubbleNodeDiagram(this)
     this.ui.svgNodeDiagram = this.svgNodeDiagram
 
     this.ui.on('setData', () => {
@@ -63,4 +64,4 @@ class SvgContainer extends HtmlContent {
   }
 }
 
-module.exports = SvgContainer
+module.exports = BubbleNodeContainer

--- a/visualizer/draw/bubble-node-container.js
+++ b/visualizer/draw/bubble-node-container.js
@@ -8,8 +8,9 @@ class BubbleNodeContainer extends HtmlContent {
     const defaultProperties = {
       htmlElementType: 'svg'
     }
-    console.log(contentProperties)
     super(parentContent, Object.assign(defaultProperties, contentProperties))
+
+    // this.renderType =
 
     if (contentProperties.svgBounds) {
       const defaultBounds = {
@@ -31,6 +32,10 @@ class BubbleNodeContainer extends HtmlContent {
     })
   }
 
+  get renderType () {
+    return this.contentProperties.htmlElementType
+  }
+
   setData () {
     const {
       minX,
@@ -40,9 +45,17 @@ class BubbleNodeContainer extends HtmlContent {
     this.svgBounds.height = this.ui.layout.scale.finalSvgHeight || this.ui.layout.settings.svgHeight
     this.svgBounds.width = this.ui.layout.settings.svgWidth
 
-    this.d3Element
-      .attr('viewBox', `${minX} ${minY} ${this.svgBounds.width} ${this.svgBounds.height}`)
-      .attr('preserveAspectRatio', preserveAspectRatio)
+    if (this.renderType === 'svg') {
+      this.d3Element
+        .attr('viewBox', `${minX} ${minY} ${this.svgBounds.width} ${this.svgBounds.height}`)
+        .attr('preserveAspectRatio', preserveAspectRatio)
+    }
+
+    if (this.renderType === 'canvas') {
+      this.d3Element
+        .attr('width', this.svgBounds.width)
+        .attr('height', this.svgBounds.height)
+    }
   }
 
   initializeElements () {

--- a/visualizer/draw/bubble-node-diagram.js
+++ b/visualizer/draw/bubble-node-diagram.js
@@ -2,9 +2,9 @@
 
 const d3 = require('./d3-subset.js')
 const LineCoordinates = require('../layout/line-coordinates.js')
-const SvgNode = require('./svg-node.js')
+const BubbleNode = require('./bubble-node.js')
 
-class SvgNodeDiagram {
+class BubbleNodeDiagram {
   constructor (svgContainer) {
     this.svgContainer = svgContainer
     this.ui = svgContainer.ui
@@ -46,7 +46,7 @@ class SvgNodeDiagram {
       .enter()
 
     this.dataArray.forEach(layoutNode => {
-      if (!this.svgNodes.has(layoutNode.id)) this.svgNodes.set(layoutNode.id, new SvgNode(this))
+      if (!this.svgNodes.has(layoutNode.id)) this.svgNodes.set(layoutNode.id, new BubbleNode(this))
       this.svgNodes.get(layoutNode.id).setData(layoutNode)
     })
   }
@@ -145,4 +145,4 @@ class SvgNodeDiagram {
   }
 }
 
-module.exports = SvgNodeDiagram
+module.exports = BubbleNodeDiagram

--- a/visualizer/draw/bubble-node-diagram.js
+++ b/visualizer/draw/bubble-node-diagram.js
@@ -5,11 +5,12 @@ const LineCoordinates = require('../layout/line-coordinates.js')
 const BubbleNode = require('./bubble-node.js')
 
 class BubbleNodeDiagram {
-  constructor (svgContainer) {
-    this.svgContainer = svgContainer
-    this.ui = svgContainer.ui
+  constructor (bubbleNodeContainer) {
+    this.bubbleNodeContainer = bubbleNodeContainer
+    this.ui = bubbleNodeContainer.ui
 
     this.svgNodes = new Map()
+    this.canvasCtx = null
 
     this.ui.on('initializeFromData', () => {
       // Called once, creates group contents using d3's .append()
@@ -32,7 +33,14 @@ class BubbleNodeDiagram {
   }
 
   initializeElements () {
-    this.d3Container = this.svgContainer.d3Element
+    if (this.bubbleNodeContainer.renderType === 'svg') {
+      this.d3Container = this.bubbleNodeContainer.d3Element
+    }
+
+    if (this.bubbleNodeContainer.renderType === 'canvas') {
+      this.canvasCtx = this.bubbleNodeContainer.d3Element.node().getContext('2d')
+      this.d3Container = d3.select(document.createElement('custom'))
+    }
 
     // Group to which one group for each node is appended
     this.d3Element = this.d3Container.append('g')
@@ -77,10 +85,10 @@ class BubbleNodeDiagram {
   animate (isExpanding, onComplete) {
     this.ui.isAnimating = true
 
-    this.svgContainer.d3Element.classed('fade-elements-in', isExpanding)
-    this.svgContainer.d3Element.classed('fade-elements-out', !isExpanding)
-    this.svgContainer.d3Element.classed('complete-fade-out', false)
-    this.svgContainer.d3Element.classed('complete-fade-in', false)
+    this.bubbleNodeContainer.d3Element.classed('fade-elements-in', isExpanding)
+    this.bubbleNodeContainer.d3Element.classed('fade-elements-out', !isExpanding)
+    this.bubbleNodeContainer.d3Element.classed('complete-fade-out', false)
+    this.bubbleNodeContainer.d3Element.classed('complete-fade-in', false)
 
     const parentContainer = this.ui.parentUI.svgNodeDiagram.svgContainer
     parentContainer.d3Element.classed('fade-elements-in', false)

--- a/visualizer/draw/bubble-node-section.js
+++ b/visualizer/draw/bubble-node-section.js
@@ -4,7 +4,7 @@ const d3 = require('./d3-subset.js')
 const LineCoordinates = require('../layout/line-coordinates.js')
 const { validateNumber } = require('../validation.js')
 
-class SvgNodeSection {
+class BubbleNodeSection {
   constructor (parentContent, settings) {
     this.parentContent = parentContent
     this.ui = parentContent.ui
@@ -30,18 +30,18 @@ class SvgNodeSection {
         .classed('inner-circle', true)
     }
 
-    const svgNodeElementClasses = {
-      SvgLine,
-      SvgBubble
+    const bubbleNodeElementClasses = {
+      BubbleNodeLine,
+      BubbleNodeBubble
     }
 
-    const SvgNodeElementClass = svgNodeElementClasses[this.shapeClass]
+    const BubbleNodeElementClass = bubbleNodeElementClasses[this.shapeClass]
 
-    this.byParty = new SvgNodeElementClass(this, this.d3NodeGroup, 'party')
+    this.byParty = new BubbleNodeElementClass(this, this.d3NodeGroup, 'party')
       .setData(this.layoutNode)
       .initializeFromData()
 
-    this.byType = new SvgNodeElementClass(this, this.d3NodeGroup, 'typeCategory')
+    this.byType = new BubbleNodeElementClass(this, this.d3NodeGroup, 'typeCategory')
       .setData(this.layoutNode)
       .initializeFromData()
   }
@@ -67,7 +67,7 @@ class SvgNodeSection {
   }
 }
 
-class SvgNodeElement {
+class BubbleNodeElement {
   constructor (parentContent, d3Group, dataType) {
     this.svgNode = parentContent.parentContent
     this.d3Group = d3Group
@@ -225,7 +225,7 @@ class SvgNodeElement {
   }
 }
 
-class SvgLine extends SvgNodeElement {
+class BubbleNodeLine extends BubbleNodeElement {
   initializeFromData () {
     const d3Enter = this.d3Group.selectAll('path.segmented-line')
       .data(this.decimalsArray)
@@ -287,7 +287,7 @@ class SvgLine extends SvgNodeElement {
   }
 }
 
-class SvgBubble extends SvgNodeElement {
+class BubbleNodeBubble extends BubbleNodeElement {
   setData (layoutNode) {
     super.setData(layoutNode)
     this.arcData = d3.pie().value((arcDatum) => arcDatum[1])(this.decimalsArray)
@@ -588,4 +588,4 @@ function getEllipseAngle (degrees) {
   return LineCoordinates.degreesToRadians(degrees + 90)
 }
 
-module.exports = SvgNodeSection
+module.exports = BubbleNodeSection

--- a/visualizer/draw/bubble-node-section.js
+++ b/visualizer/draw/bubble-node-section.js
@@ -3,8 +3,7 @@
 const d3 = require('./d3-subset.js')
 const LineCoordinates = require('../layout/line-coordinates.js')
 const { validateNumber } = require('../validation.js')
-const getCSSVarValue = require('./util/getCssVarValue.js')
-const cssVarValues = getCSSVarValue()
+const canvasStyles = require('./util/canvasStyles.js')
 
 class BubbleNodeSection {
   constructor (parentContent, settings) {
@@ -228,53 +227,6 @@ class BubbleNodeElement {
       .ease(this.ui.settings.animationEasing)
       .attr('d', endPath)
   }
-
-  canvasStyles () {
-    const strokeStyles = {
-      'party-user': cssVarValues('--party-colour-1'),
-      'party-external': cssVarValues('--party-colour-2'),
-      'party-nodecore': cssVarValues('--party-colour-3'),
-      'party-root': cssVarValues('--party-colour-3'),
-      'type-files-streams': cssVarValues('--type-colour-1'),
-      'type-networks': cssVarValues('--type-colour-2'),
-      'type-crypto': cssVarValues('--type-colour-3'),
-      'type-timing-promises': cssVarValues('--type-colour-4'),
-      'type-other': cssVarValues('--type-colour-5')
-    }
-
-    const solid = []
-    const dashed = [1.3, 0.7]
-
-    const strokeDash = {
-      'party-user': solid,
-      'party-external': solid,
-      'party-nodecore': dashed,
-      'party-root': dashed,
-      'type-files-streams': dashed,
-      'type-networks': solid,
-      'type-crypto': dashed,
-      'type-timing-promises': solid,
-      'type-other': dashed
-    }
-
-    const lineWidths = {
-      'party-user': 1.5,
-      'party-external': 1.5,
-      'party-nodecore': 1.5,
-      'party-root': 1.5,
-      'type-files-streams': 3.5,
-      'type-networks': 3.5,
-      'type-crypto': 3.5,
-      'type-timing-promises': 3.5,
-      'type-other': 3.5
-    }
-
-    return {
-      strokeStyles,
-      strokeDash,
-      lineWidths
-    }
-  }
 }
 
 class BubbleNodeLine extends BubbleNodeElement {
@@ -336,11 +288,11 @@ class BubbleNodeLine extends BubbleNodeElement {
       const segmentPath = getLineUpdatingOrigin(currentOrigin, this.degrees, this.length * segmentDatum[1])
 
       if (this.canvasCtx) {
-        const { strokeStyles, lineWidths, strokeDash } = this.canvasStyles()
+        const { colours, lineWidths, strokeDash } = canvasStyles()
 
         const styleId = d3LineSegment.attr('styleId')
         this.canvasCtx.beginPath()
-        this.canvasCtx.strokeStyle = strokeStyles[styleId]
+        this.canvasCtx.strokeStyle = colours[styleId]
         this.canvasCtx.lineWidth = lineWidths[styleId]
         this.canvasCtx.setLineDash(strokeDash[styleId])
         const canvaspath = new window.Path2D(segmentPath)
@@ -398,12 +350,12 @@ class BubbleNodeBubble extends BubbleNodeElement {
       const adjustedArc = adjustArcPath(initialArc, this)
 
       if (this.canvasCtx) {
-        const { strokeStyles, lineWidths, strokeDash } = this.canvasStyles()
+        const { colours, lineWidths, strokeDash } = canvasStyles()
 
         const node = d3.select(nodes[i])
         const styleId = node.attr('styleId')
         this.canvasCtx.beginPath()
-        this.canvasCtx.strokeStyle = strokeStyles[styleId]
+        this.canvasCtx.strokeStyle = colours[styleId]
         this.canvasCtx.lineWidth = lineWidths[styleId]
         this.canvasCtx.setLineDash(strokeDash[styleId])
         const canvaspath = new window.Path2D(adjustedArc)

--- a/visualizer/draw/bubble-node.js
+++ b/visualizer/draw/bubble-node.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const LineCoordinates = require('../layout/line-coordinates.js')
-const SvgNodeSection = require('./svg-node-section.js')
+const BubbleNodeSection = require('./bubble-node-section.js')
 
-class SvgNode {
+class BubbleNode {
   constructor (parentContent) {
     this.parentContent = parentContent
     this.ui = parentContent.ui
@@ -13,13 +13,13 @@ class SvgNode {
     this.degrees = null
     this.originPoint = null
 
-    this.asyncBetweenLines = new SvgNodeSection(this, {
+    this.asyncBetweenLines = new BubbleNodeSection(this, {
       dataPosition: 'between',
-      shapeClass: 'SvgLine'
+      shapeClass: 'BubbleNodeLine'
     })
-    this.syncBubbles = new SvgNodeSection(this, {
+    this.syncBubbles = new BubbleNodeSection(this, {
       dataPosition: 'within',
-      shapeClass: 'SvgBubble'
+      shapeClass: 'BubbleNodeBubble'
     })
   }
 
@@ -506,4 +506,4 @@ function formatNameLabel (string) {
   return string
 }
 
-module.exports = SvgNode
+module.exports = BubbleNode

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -152,8 +152,10 @@ class BubbleprofUI extends EventEmitter {
       sublayoutHtml.addCollapseControl()
       const closeBtn = sublayoutHtml.addContent(undefined, { classNames: 'close-btn' })
 
-      const sublayoutSvg = sublayoutHtml.addContent('SvgContainer', { id: 'sublayout-svg', svgBounds: {} })
+      const sublayoutSvg = sublayoutHtml.addContent('BubbleNodeContainer', { id: 'sublayout-svg', svgBounds: {} })
       sublayoutHtml.addContent('HoverBox', { svg: sublayoutSvg })
+
+      // const sublayoutCanvas = sublayoutHtml.addContent('BubbleNodeContainer', { htmlElementType: 'canvas', id: 'sublayout-canvas', svgBounds: {} })
 
       uiWithinSublayout.initializeElements()
 

--- a/visualizer/draw/bubbleprof-ui.js
+++ b/visualizer/draw/bubbleprof-ui.js
@@ -152,10 +152,10 @@ class BubbleprofUI extends EventEmitter {
       sublayoutHtml.addCollapseControl()
       const closeBtn = sublayoutHtml.addContent(undefined, { classNames: 'close-btn' })
 
-      const sublayoutSvg = sublayoutHtml.addContent('BubbleNodeContainer', { id: 'sublayout-svg', svgBounds: {} })
-      sublayoutHtml.addContent('HoverBox', { svg: sublayoutSvg })
+      // const sublayoutSvg = sublayoutHtml.addContent('BubbleNodeContainer', { id: 'sublayout-svg', svgBounds: {} })
+      // sublayoutHtml.addContent('HoverBox', { svg: sublayoutSvg })
 
-      // const sublayoutCanvas = sublayoutHtml.addContent('BubbleNodeContainer', { htmlElementType: 'canvas', id: 'sublayout-canvas', svgBounds: {} })
+      const sublayoutCanvas = sublayoutHtml.addContent('BubbleNodeContainer', { htmlElementType: 'canvas', id: 'sublayout-canvas', svgBounds: {} })
 
       uiWithinSublayout.initializeElements()
 

--- a/visualizer/draw/html-content-types.js
+++ b/visualizer/draw/html-content-types.js
@@ -13,6 +13,6 @@ module.exports = {
   InteractiveKey: require('./interactive-key.js'),
   AreaChart: require('./area-chart.js'),
   Lookup: require('./lookup.js'),
-  SvgContainer: require('./svg-container.js'),
+  BubbleNodeContainer: require('./bubble-node-container.js'),
   SideBarDrag: require('./side-bar-drag.js')
 }

--- a/visualizer/draw/index.js
+++ b/visualizer/draw/index.js
@@ -164,9 +164,11 @@ function drawOuterUI () {
   // Main panel - nodelink diagram
   const nodeLink = ui.sections.get('node-link')
 
-  const nodeLinkSVG = nodeLink.addContent('SvgContainer', { id: 'node-link-svg', svgBounds: {} })
-
+  const nodeLinkSVG = nodeLink.addContent('BubbleNodeContainer', { id: 'node-link-svg', svgBounds: {} })
   nodeLink.addContent('HoverBox', { svg: nodeLinkSVG })
+
+  // const nodeLinkCanvas = nodeLink.addContent('BubbleNodeContainer', { htmlElementType: 'canvas', id: 'node-link-svg', svgBounds: {} })
+  // nodeLink.addContent('HoverBox', { svg: nodeLinkSVG })
 
   // Sidebar
   const sideBar = ui.sections.get('side-bar')

--- a/visualizer/draw/index.js
+++ b/visualizer/draw/index.js
@@ -164,10 +164,10 @@ function drawOuterUI () {
   // Main panel - nodelink diagram
   const nodeLink = ui.sections.get('node-link')
 
-  const nodeLinkSVG = nodeLink.addContent('BubbleNodeContainer', { id: 'node-link-svg', svgBounds: {} })
-  nodeLink.addContent('HoverBox', { svg: nodeLinkSVG })
+  // const nodeLinkSVG = nodeLink.addContent('BubbleNodeContainer', { id: 'node-link-svg', svgBounds: {} })
+  // nodeLink.addContent('HoverBox', { svg: nodeLinkSVG })
 
-  // const nodeLinkCanvas = nodeLink.addContent('BubbleNodeContainer', { htmlElementType: 'canvas', id: 'node-link-svg', svgBounds: {} })
+  const nodeLinkCanvas = nodeLink.addContent('BubbleNodeContainer', { htmlElementType: 'canvas', id: 'node-link-svg', svgBounds: {} })
   // nodeLink.addContent('HoverBox', { svg: nodeLinkSVG })
 
   // Sidebar

--- a/visualizer/draw/util/canvasStyles.js
+++ b/visualizer/draw/util/canvasStyles.js
@@ -1,0 +1,53 @@
+const getCssVarValue = require('./getCssVarValue')
+const cssVarValues = getCssVarValue()
+
+module.exports = function canvasStyles () {
+  const colours = {
+    'party-user': cssVarValues('--party-colour-1'),
+    'party-external': cssVarValues('--party-colour-2'),
+    'party-nodecore': cssVarValues('--party-colour-3'),
+    'party-root': cssVarValues('--party-colour-3'),
+    'type-files-streams': cssVarValues('--type-colour-1'),
+    'type-networks': cssVarValues('--type-colour-2'),
+    'type-crypto': cssVarValues('--type-colour-3'),
+    'type-timing-promises': cssVarValues('--type-colour-4'),
+    'type-other': cssVarValues('--type-colour-5'),
+    'outer-path': cssVarValues('---node-background'),
+    'outer-path-stroke': cssVarValues('--shortcut-stroke'),
+    'selected-node': cssVarValues('--highlight-bg-color)')
+  }
+
+  const solid = []
+  const dashed = [1.3, 0.7]
+
+  const strokeDash = {
+    'party-user': solid,
+    'party-external': solid,
+    'party-nodecore': dashed,
+    'party-root': dashed,
+    'type-files-streams': dashed,
+    'type-networks': solid,
+    'type-crypto': dashed,
+    'type-timing-promises': solid,
+    'type-other': dashed
+  }
+
+  const lineWidths = {
+    'party-user': 1.5,
+    'party-external': 1.5,
+    'party-nodecore': 1.5,
+    'party-root': 1.5,
+    'type-files-streams': 3.5,
+    'type-networks': 3.5,
+    'type-crypto': 3.5,
+    'type-timing-promises': 3.5,
+    'type-other': 3.5,
+    'outer-path': 0.5
+  }
+
+  return {
+    colours,
+    strokeDash,
+    lineWidths
+  }
+}

--- a/visualizer/draw/util/getCssVarValue.js
+++ b/visualizer/draw/util/getCssVarValue.js
@@ -1,0 +1,14 @@
+/**
+* Get the value of a CSS variable
+* @param {String} varName
+*/
+
+module.exports = function () {
+  const cssVarValues = {}
+  return function getCSSVarValue (varName) {
+    if (!cssVarValues[varName]) {
+      cssVarValues[varName] = window.getComputedStyle(document.body).getPropertyValue(varName)
+    }
+    return cssVarValues[varName]
+  }
+}


### PR DESCRIPTION
This  is a work in progress 

- [x] renames files and modules to remove SVG assumption
- [x] adds Canvas as an alternate (not necessary replacement) for SVG  - will open possibility to keep SVG where it desired
- [x] renders layout with canvas
- [x] renders node lines and bubbles with canvas
- [ ] renders labels in canvas [WIP: currently working through text measurement in cancas
- [ ] establish a method to maintain styles across SVG and canvas [WIP: as we go - we'll do our best]
- [ ] add interaction layer to Canvas rendering
- [ ] add animation to Canvas rendering
- [ ] abstract the methods to a generic use case - for future D3 in SVG/Canvas (nice to have)

### ongoing notes and thoughts: 
SVG is deeply embedded in the way this has been initially authored. I have decided to maintain the SVG rendering capability, and use the D3 node creation as a data-binding layer that is also used in the canvas rendering methods. This is a common pattern in D3 for canvas. 

I am also looking for opportunities to be more declarative with the rendering methods - so the relevant rendering data model for the visualisation state can be defined separately and actual rendering is a more abstracted function call  - to be called on load/animation frame/ interaction etc. in a 'reactive' way. This probably will require more architectural thinking and a rework of the current bubbleprof frontend.

Questions about efficiency of canvas animation redraws vs native CSS animations. 
Also managing modularity of canvas 'elements'  - where this is built in to DOM nodes in SVG. 












