### PR TITLE
Fix NODE_PATH for legacy projects

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ const buildJs = require('@nearform/clinic-common/scripts/build-js')
 const buildCss = require('@nearform/clinic-common/scripts/build-css')
 const mainTemplate = require('@nearform/clinic-common/templates/main')
 
+const makeInjectPath = (fileName) => {
+  return path.join(__dirname, 'injects', fileName);
+};
+
 class ClinicBubbleprof extends events.EventEmitter {
   constructor (settings = {}) {
     super()
@@ -35,20 +39,19 @@ class ClinicBubbleprof extends events.EventEmitter {
   collect (args, callback) {
     // run program, but inject the sampler
     const logArgs = [
-      '-r', 'no-cluster.js',
-      '-r', 'logger.js',
+      '-r', makeInjectPath('no-cluster.js'),
+      '-r', makeInjectPath('logger.js'),
       '--trace-events-enabled', '--trace-event-categories', 'node.async_hooks'
     ]
 
     const stdio = ['inherit', 'inherit', 'inherit']
 
     if (this.detectPort) {
-      logArgs.push('-r', 'detect-port.js')
+      logArgs.push('-r', makeInjectPath('detect-port.js'))
       stdio.push('pipe')
     }
 
     const customEnv = {
-      NODE_PATH: path.join(__dirname, 'injects'),
       NODE_OPTIONS: logArgs.join(' ') + (
         process.env.NODE_OPTIONS ? ' ' + process.env.NODE_OPTIONS : ''
       )

--- a/index.js
+++ b/index.js
@@ -17,8 +17,6 @@ const buildJs = require('@nearform/clinic-common/scripts/build-js')
 const buildCss = require('@nearform/clinic-common/scripts/build-css')
 const mainTemplate = require('@nearform/clinic-common/templates/main')
 
-const makeInjectPath = fileName => path.join(__dirname, 'injects', fileName)
-
 class ClinicBubbleprof extends events.EventEmitter {
   constructor (settings = {}) {
     super()
@@ -37,15 +35,15 @@ class ClinicBubbleprof extends events.EventEmitter {
   collect (args, callback) {
     // run program, but inject the sampler
     const logArgs = [
-      '-r', makeInjectPath('no-cluster.js'),
-      '-r', makeInjectPath('logger.js'),
+      '-r', 'no-cluster.js',
+      '-r', 'logger.js',
       '--trace-events-enabled', '--trace-event-categories', 'node.async_hooks'
     ]
 
     const stdio = ['inherit', 'inherit', 'inherit']
 
     if (this.detectPort) {
-      logArgs.push('-r', makeInjectPath('detect-port.js'))
+      logArgs.push('-r', 'detect-port.js')
       stdio.push('pipe')
     }
 

--- a/index.js
+++ b/index.js
@@ -17,9 +17,7 @@ const buildJs = require('@nearform/clinic-common/scripts/build-js')
 const buildCss = require('@nearform/clinic-common/scripts/build-css')
 const mainTemplate = require('@nearform/clinic-common/templates/main')
 
-const makeInjectPath = (fileName) => {
-  return path.join(__dirname, 'injects', fileName)
-}
+const makeInjectPath = fileName => path.join(__dirname, 'injects', fileName)
 
 class ClinicBubbleprof extends events.EventEmitter {
   constructor (settings = {}) {

--- a/index.js
+++ b/index.js
@@ -49,7 +49,14 @@ class ClinicBubbleprof extends events.EventEmitter {
       stdio.push('pipe')
     }
 
+    let NODE_PATH = path.join(__dirname, 'injects')
+    // use NODE_PATH to work around issues with spaces in inject path
+    if (process.env.NODE_PATH) {
+      NODE_PATH += `${process.platform === 'win32' ? ';' : ':'}${process.env.NODE_PATH}`
+    }
+
     const customEnv = {
+      NODE_PATH,
       NODE_OPTIONS: logArgs.join(' ') + (
         process.env.NODE_OPTIONS ? ' ' + process.env.NODE_OPTIONS : ''
       )

--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ const buildCss = require('@nearform/clinic-common/scripts/build-css')
 const mainTemplate = require('@nearform/clinic-common/templates/main')
 
 const makeInjectPath = (fileName) => {
-  return path.join(__dirname, 'injects', fileName);
-};
+  return path.join(__dirname, 'injects', fileName)
+}
 
 class ClinicBubbleprof extends events.EventEmitter {
   constructor (settings = {}) {


### PR DESCRIPTION
Seems this doesn't matter anymore

https://github.com/nearform/node-clinic-doctor/pull/132

But ths still relates to current state
https://github.com/nearform/node-clinic/issues/148

So there might be changes done to fix NODE_PATH back, for legacy projects.