### PR TITLE
fix cluster test

### DIFF
--- a/test/cmd-no-cluster.cluster.js
+++ b/test/cmd-no-cluster.cluster.js
@@ -1,0 +1,4 @@
+const cluster = require('cluster')
+if (cluster.isMaster) {
+  cluster.fork()
+}

--- a/test/cmd-no-cluster.script.js
+++ b/test/cmd-no-cluster.script.js
@@ -1,10 +1,11 @@
+const path = require('path')
 const rimraf = require('rimraf')
 const ClinicBubbleprof = require('../index.js')
 
 const bubble = new ClinicBubbleprof({})
 bubble.collect([
   process.execPath,
-  '-e', 'var c = require("cluster"); c.isMaster && c.fork()'
+  path.join(__dirname, 'cmd-no-cluster.cluster.js')
 ], (err, result) => {
   rimraf.sync(result)
   if (err) throw err


### PR DESCRIPTION
same as https://github.com/nearform/node-clinic-doctor/pull/242

cluster.fork doesn't work if you use it from `node -e`, this test should never have worked but it passed silently for a long time!