### PR TITLE
Fix tests on Node 12.16

### DIFF
--- a/test/cmd-collect.test.js
+++ b/test/cmd-collect.test.js
@@ -83,7 +83,7 @@ test('collect command produces data files with content', function (t) {
         // Node.js 13 does not appear to show this `resolve()` call in its trace event log.
           : semver.satisfies(process.version, '>= 12.16.0 < 13.0.0')
             ? ['PROMISE', 'Timeout']
-            : ['Timeout'] // default
+            : ['Timeout']
 
       t.strictDeepEqual(asyncOperationTypes.sort(), expected)
 

--- a/test/cmd-collect.test.js
+++ b/test/cmd-collect.test.js
@@ -76,7 +76,7 @@ test('collect command produces data files with content', function (t) {
       }
 
       const expected =
-        // Expect Timeout and TIMERWRAP to be there in Node 10.x and below
+        // Expect Timeout and TIMERWRAP to be there in Node 10.x and below. TIMERWRAP was removed in https://github.com/nodejs/node/pull/20894
         semver.satisfies(process.version, '< 11.0')
           ? ['TIMERWRAP', 'Timeout']
         // A `Promise.resolve()` call was added to bootstrap code in Node 12.16.x: https://github.com/nodejs/node/pull/30624

--- a/test/integration-timeout.test.js
+++ b/test/integration-timeout.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const test = require('tap').test
+const semver = require('semver')
 const endpoint = require('endpoint')
 const CollectAndRead = require('./collect-and-read.js')
 const analysis = require('../analysis/index.js')
@@ -21,11 +22,18 @@ test('collect-analysis pipeline', function (t) {
         const nodeMap = new Map(
           aggregateNodes.map((node) => [node.aggregateId, node])
         )
-        t.strictEqual(nodes.length, 2)
-        t.strictEqual(nodeMap.size, 2)
+        if (semver.satisfies(process.version, '>= 12.16.0 < 13.0.0')) {
+          t.strictEqual(nodes.length, 3)
+          t.strictEqual(nodeMap.size, 3)
+          // aggregateId = 1 is the root and points to the Timeout and a PROMISE from Node.js's initialization code
+          t.strictDeepEqual(nodeMap.get(1).children, [2, 3])
+        } else {
+          t.strictEqual(nodes.length, 2)
+          t.strictEqual(nodeMap.size, 2)
+          // aggregateId = 1 is the root and points to the Timeout
+          t.strictDeepEqual(nodeMap.get(1).children, [2])
+        }
 
-        // aggregateId = 1 is the root and points to the Timeout
-        t.strictDeepEqual(nodeMap.get(1).children, [2])
         // aggregateId = 2 is the Timeout
         t.strictEqual(nodeMap.get(2).sources[0].type, 'Timeout')
 


### PR DESCRIPTION
https://github.com/nodejs/node/pull/30624 means the `-e` flag now uses the esm module initialization code which includes a Promise.resolve() call which generates a trace event in Node.js 12.16.

Closes https://github.com/nearform/node-clinic-bubbleprof/issues/352