### PR TITLE
Transpiled code warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,6 @@ class ClinicBubbleprof extends events.EventEmitter {
       }
       if (data.toString() === 'source_warning') {
         this.emit('warning', 'The code is transpiled, bubbleprof does not support source maps yet.')
-        proc.stdio[3].destroy()
       }
     })
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ class ClinicBubbleprof extends events.EventEmitter {
 
     if (this.detectPort) {
       logArgs.push('-r', 'detect-port.js')
-      stdio.push('pipe')
     }
 
     let NODE_PATH = path.join(__dirname, 'injects')
@@ -69,11 +68,10 @@ class ClinicBubbleprof extends events.EventEmitter {
       env: Object.assign({}, process.env, customEnv)
     })
 
-    proc.stdio[3].once('data', data => { 
+    proc.stdio[3].once('data', data => {
       if (this.detectPort) {
         this.emit('port', Number(data), proc, () => proc.stdio[3].destroy())
-      }
-      else if (data.toString() === 'source_warning') {
+      } else if (data.toString() === 'source_warning') {
         this.emit('warning', 'The code is transpiled, bubbleprof does not support source maps yet.')
         proc.stdio[3].destroy()
       }

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ class ClinicBubbleprof extends events.EventEmitter {
         this.emit('port', Number(data), proc, () => proc.stdio[3].destroy())
       }
       else if (data.toString() === 'source_warning') {
-        this.emit('warning', 'Transpiled code is not supported')
+        this.emit('warning', 'The code is transpiled, bubbleprof does not support source maps yet.')
         proc.stdio[3].destroy()
       }
     })

--- a/index.js
+++ b/index.js
@@ -71,7 +71,8 @@ class ClinicBubbleprof extends events.EventEmitter {
     proc.stdio[3].once('data', data => {
       if (this.detectPort) {
         this.emit('port', Number(data), proc, () => proc.stdio[3].destroy())
-      } else if (data.toString() === 'source_warning') {
+      }
+      if (data.toString() === 'source_warning') {
         this.emit('warning', 'The code is transpiled, bubbleprof does not support source maps yet.')
         proc.stdio[3].destroy()
       }

--- a/injects/logger.js
+++ b/injects/logger.js
@@ -7,30 +7,7 @@ const stackTrace = require('../collect/stack-trace.js')
 const systemInfo = require('../collect/system-info.js')
 const StackTraceEncoder = require('../format/stack-trace-encoder.js')
 const getLoggingPaths = require('@nearform/clinic-common').getLoggingPaths('bubbleprof')
-
-function checkForTranspiledCode (filename) {
-  const readFile = fs.readFileSync(filename, 'utf8')
-  const regex = /function\s+(?<functionName>\w+)/g
-  let matchedObj
-  let isTranspiled = false
-
-  // Check for a source map
-  isTranspiled = readFile.includes('//# sourceMappingURL=')
-
-  while ((matchedObj = regex.exec(readFile)) !== null) {
-    // Avoid infinite loops with zero-width matches
-    if (matchedObj.index === regex.lastIndex) {
-      regex.lastIndex++
-    }
-    // Loop through results and check length of fn name
-    matchedObj.forEach((match, groupIndex) => {
-      if (groupIndex !== 0 && match.length < 3) {
-        isTranspiled = true
-      }
-    })
-  }
-  return isTranspiled
-}
+const checkForTranspiledCode = require('@nearform/clinic-common').checkForTranspiledCode
 
 process.nextTick(function () {
   if (process.mainModule && checkForTranspiledCode(process.mainModule.filename)) {

--- a/injects/logger.js
+++ b/injects/logger.js
@@ -56,18 +56,15 @@ const out = encoder.pipe(
 // log stack traces, export a flag to opt out of logging for internals
 exports.skipThis = false
 const skipAsyncIds = new Set()
-let firedOnce = false;
+let firedOnce = false
 
 const hook = asyncHooks.createHook({
-  before () {
+  init (asyncId, type, triggerAsyncId) {
     if (!firedOnce && process.mainModule && checkForTranspiledCode(process.mainModule.filename)) {
       // Show warning to user
       fs.writeSync(3, 'source_warning', null, 'utf8')
       firedOnce = true
     }
-  },
-
-  init (asyncId, type, triggerAsyncId) {
     // Save the asyncId such nested async operations can be skiped later.
     if (exports.skipThis) return skipAsyncIds.add(asyncId)
     // This is a nested async operations, skip this and track futher nested

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "keywords": [],
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@nearform/clinic-common": "^2.0.0",
+    "@nearform/clinic-common": "nearform/node-clinic-common#transpiled_warning",
     "@nearform/trace-events-parser": "^1.0.4",
     "array-flatten": "^3.0.0",
     "async": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "@nearform/bubbleprof",
   "description": "Programmable interface to Clinic.js Bubbleprof",
   "repository": "nearform/node-clinic-bubbleprof",
-  "version": "3.0.1",
+  "version": "3.0.3",
   "engines": {
-    "node": "^13.0.0 || ^12.0.0 || ^11.0.0 || ^10.0.0 || ^8.11.1"
+    "node": ">=10.12.0"
   },
   "scripts": {
     "test": "standard | snazzy && tap -j1 --no-cov --timeout=50 test/*.test.js",
@@ -32,7 +32,7 @@
   "keywords": [],
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@nearform/clinic-common": "nearform/node-clinic-common#transpiled_warning",
+    "@nearform/clinic-common": "^2.3.0",
     "@nearform/trace-events-parser": "^1.0.4",
     "array-flatten": "^3.0.0",
     "async": "^3.0.1",


### PR DESCRIPTION
Detect transpiled code by using a median of function name length and provide warning to the user. Also checks file for a source map comment.