### PR TITLE
Display bubbleprof version beneath logo

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,6 +158,8 @@ class ClinicBubbleprof extends events.EventEmitter {
     const nearFormLogoFile = fs.createReadStream(nearFormLogoPath)
     const clinicFaviconBase64 = fs.createReadStream(clinicFaviconPath)
 
+    const bubbleprofVersion = require('./package.json').version
+
     dataFile.on('warning', msg => this.emit('warning', msg))
 
     // build JS
@@ -187,6 +189,7 @@ class ClinicBubbleprof extends events.EventEmitter {
       headerLogoTitle: 'Clinic Bubbleprof on Clinicjs.org',
       headerLogo: logoFile,
       headerText: 'Bubbleprof',
+      toolVersion: bubbleprofVersion,
       nearFormLogo: nearFormLogoFile,
       uploadId: outputFilename.split('/').pop().split('.html').shift(),
       body: '<div class="ncb-font-spinner-container"></div>'


### PR DESCRIPTION
Pass the tool version to the html template.

<img width="487" alt="Screenshot 2020-04-30 at 16 22 33" src="https://user-images.githubusercontent.com/43864112/80728418-d0f0f500-8afe-11ea-9aa3-5a8ca225c3ec.png">

[Issue FK02](https://trello.com/c/vgIgBXME/843-fk02-visibility-of-system-status)