### PR TITLE
fix: visualizer source delayStart must precede source before

### DIFF
--- a/test/cmd-collect.test.js
+++ b/test/cmd-collect.test.js
@@ -80,8 +80,8 @@ test('collect command produces data files with content', function (t) {
         semver.satisfies(process.version, '< 11.0')
           ? ['TIMERWRAP', 'Timeout']
         // A `Promise.resolve()` call was added to bootstrap code in Node 12.16.x: https://github.com/nodejs/node/pull/30624
-        // Node.js 13 does not appear to show this `resolve()` call in its trace event log.
-          : semver.satisfies(process.version, '>= 12.16.0 < 13.0.0')
+        // Node.js 12.17.0 does not appear to show this `resolve()` call in its trace event log.
+          : semver.satisfies(process.version, '>= 12.16.0 < 12.17.0')
             ? ['PROMISE', 'Timeout']
             : ['Timeout']
 

--- a/test/integration-timeout.test.js
+++ b/test/integration-timeout.test.js
@@ -22,7 +22,7 @@ test('collect-analysis pipeline', function (t) {
         const nodeMap = new Map(
           aggregateNodes.map((node) => [node.aggregateId, node])
         )
-        if (semver.satisfies(process.version, '>= 12.16.0 < 13.0.0')) {
+        if (semver.satisfies(process.version, '>= 12.16.0 < 12.17.0')) {
           t.strictEqual(nodes.length, 3)
           t.strictEqual(nodeMap.size, 3)
           // aggregateId = 1 is the root and points to the Timeout and a PROMISE from Node.js's initialization code

--- a/visualizer/data/callback-event.js
+++ b/visualizer/data/callback-event.js
@@ -5,8 +5,14 @@
 // we need to look at each call to these callbacks, relative to its source
 class CallbackEvent {
   constructor (callKey, source) {
-    // Timestamp when this became the next call to this callback
-    this.delayStart = callKey === 0 ? source.init : Math.max(source.before[callKey - 1], source.after[callKey - 1])
+
+    // the sequence of timestamps should be
+    // 1. this.delayStart (earliest, i.e. lowest number)
+    // 2. this.before 
+    // 3. this.after (latest, i.e. highest number)
+
+    // Timestamp when this became the next call to this callback - must be earlier or equal to before 
+    this.delayStart = callKey === 0 ? source.init : Math.min(source.before[callKey - 1], source.after[callKey - 1])
 
     // In rare cases, possibly due to a bug in streams or event tracing, .before timestamps may be greater
     // than .after timestamps. If this happens, sort them, warn the user, and provide debug data

--- a/visualizer/data/callback-event.js
+++ b/visualizer/data/callback-event.js
@@ -5,13 +5,12 @@
 // we need to look at each call to these callbacks, relative to its source
 class CallbackEvent {
   constructor (callKey, source) {
-
     // the sequence of timestamps should be
     // 1. this.delayStart (earliest, i.e. lowest number)
-    // 2. this.before 
+    // 2. this.before
     // 3. this.after (latest, i.e. highest number)
 
-    // Timestamp when this became the next call to this callback - must be earlier or equal to before 
+    // Timestamp when this became the next call to this callback - must be earlier or equal to before
     this.delayStart = callKey === 0 ? source.init : Math.min(source.before[callKey - 1], source.after[callKey - 1])
 
     // In rare cases, possibly due to a bug in streams or event tracing, .before timestamps may be greater

--- a/visualizer/data/callback-event.js
+++ b/visualizer/data/callback-event.js
@@ -7,11 +7,11 @@ class CallbackEvent {
   constructor (callKey, source) {
     // the sequence of timestamps should be
     // 1. this.delayStart (earliest, i.e. lowest number)
-    // 2. this.before
+    // 2. this.before (equal or greater than delayStart)
     // 3. this.after (latest, i.e. highest number)
 
-    // Timestamp when this became the next call to this callback - must be earlier or equal to before
-    this.delayStart = callKey === 0 ? source.init : Math.min(source.before[callKey - 1], source.after[callKey - 1])
+    // Timestamp when this became the next call to this callback
+    this.delayStart = callKey === 0 ? source.init : Math.max(source.before[callKey - 1], source.after[callKey - 1])
 
     // In rare cases, possibly due to a bug in streams or event tracing, .before timestamps may be greater
     // than .after timestamps. If this happens, sort them, warn the user, and provide debug data
@@ -23,6 +23,10 @@ class CallbackEvent {
     // Timestamp when this callback call completes
     this.after = source[this.inverted ? 'before' : 'after'][callKey]
 
+    // delayStart cannot be after before callback
+    if (this.delayStart > this.before) {
+      this.delayStart = this.before
+    }
     this.aggregateNode = source.aggregateNode
 
     if (source.dataSet.settings.debugMode) {


### PR DESCRIPTION
Fixes a reported bug where the incorrect segments start time was being set to after end time

before: 
![image](https://user-images.githubusercontent.com/395101/86234653-2c873f80-bb8f-11ea-9b8e-8f1f66eaf5bf.png)


after: 
![image](https://user-images.githubusercontent.com/395101/86236302-c51ebf00-bb91-11ea-8366-36569479170f.png)


note: the provided data _does_ contain a separate instance of inverted before/after values - which is handled  with a warning
![image](https://user-images.githubusercontent.com/395101/86236247-b0422b80-bb91-11ea-82ff-63be3b285370.png)
 

Fixes #363